### PR TITLE
Remove example mapping for external api call property causing failure

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/config/WebClientConfiguration.kt
@@ -3,15 +3,13 @@ package uk.gov.justice.digital.hmpps.findandreferanintervention.config
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
 import org.springframework.web.reactive.function.client.WebClient
-import uk.gov.justice.hmpps.kotlin.auth.authorisedWebClient
 import uk.gov.justice.hmpps.kotlin.auth.healthWebClient
 import java.time.Duration
 
 @Configuration
 class WebClientConfiguration(
-  @Value("\${example-api.url}") val exampleApiBaseUri: String,
+  // @Value("\${example-api.url}") val exampleApiBaseUri: String,
   @Value("\${hmpps-auth.url}") val hmppsAuthBaseUri: String,
   @Value("\${api.health-timeout:2s}") val healthTimeout: Duration,
   @Value("\${api.timeout:20s}") val timeout: Duration,
@@ -22,11 +20,11 @@ class WebClientConfiguration(
   fun hmppsAuthHealthWebClient(builder: WebClient.Builder): WebClient = builder.healthWebClient(hmppsAuthBaseUri, healthTimeout)
 
   // TODO: This is an example health bean for checking other services and should be removed / replaced
-  @Bean
-  fun exampleApiHealthWebClient(builder: WebClient.Builder): WebClient = builder.healthWebClient(exampleApiBaseUri, healthTimeout)
+  // @Bean
+  // fun exampleApiHealthWebClient(builder: WebClient.Builder): WebClient = builder.healthWebClient(exampleApiBaseUri, healthTimeout)
 
   // TODO: This is an example bean for calling other services and should be removed / replaced
-  @Bean
-  fun exampleApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: WebClient.Builder): WebClient =
-    builder.authorisedWebClient(authorizedClientManager, registrationId = "example-api", url = exampleApiBaseUri, timeout)
+  // @Bean
+  // fun exampleApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: WebClient.Builder): WebClient =
+  //   builder.authorisedWebClient(authorizedClientManager, registrationId = "example-api", url = exampleApiBaseUri, timeout)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/health/HealthPingCheck.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/health/HealthPingCheck.kt
@@ -11,5 +11,7 @@ import uk.gov.justice.hmpps.kotlin.health.HealthPingCheck
 class HmppsAuthHealthPing(@Qualifier("hmppsAuthHealthWebClient") webClient: WebClient) : HealthPingCheck(webClient)
 
 // TODO: Example ping health check calling out to other services
-@Component("exampleApi")
-class ExampleApiHealthPing(@Qualifier("exampleApiHealthWebClient") webClient: WebClient) : HealthPingCheck(webClient)
+// @Component("exampleApi")
+// class ExampleApiHealthPing(@Qualifier("exampleApiHealthWebClient") webClient: WebClient) : HealthPingCheck(webClient)
+
+class Dummy()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/ExampleResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/ExampleResourceIntTest.kt
@@ -1,15 +1,7 @@
 package uk.gov.justice.digital.hmpps.findandreferanintervention.integration
 
-import com.github.tomakehurst.wiremock.client.WireMock
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.findandreferanintervention.integration.wiremock.ExampleApiExtension.Companion.exampleApi
-import uk.gov.justice.digital.hmpps.findandreferanintervention.integration.wiremock.HmppsAuthApiExtension.Companion.hmppsAuth
-import java.time.LocalDate
-
-class ExampleResourceIntTest : IntegrationTestBase() {
+class ExampleResourceIntTest
+/*: IntegrationTestBase() {
 
   @Nested
   @DisplayName("GET /example/time")
@@ -127,3 +119,4 @@ class ExampleResourceIntTest : IntegrationTestBase() {
     }
   }
 }
+*/

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/IntegrationTestBase.kt
@@ -7,13 +7,11 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDO
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.findandreferanintervention.integration.wiremock.ExampleApiExtension
-import uk.gov.justice.digital.hmpps.findandreferanintervention.integration.wiremock.ExampleApiExtension.Companion.exampleApi
 import uk.gov.justice.digital.hmpps.findandreferanintervention.integration.wiremock.HmppsAuthApiExtension
 import uk.gov.justice.digital.hmpps.findandreferanintervention.integration.wiremock.HmppsAuthApiExtension.Companion.hmppsAuth
 import uk.gov.justice.hmpps.test.kotlin.auth.JwtAuthorisationHelper
 
-@ExtendWith(HmppsAuthApiExtension::class, ExampleApiExtension::class)
+@ExtendWith(HmppsAuthApiExtension::class) // , ExampleApiExtension::class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
 abstract class IntegrationTestBase {
@@ -32,6 +30,6 @@ abstract class IntegrationTestBase {
 
   protected fun stubPingWithResponse(status: Int) {
     hmppsAuth.stubHealthPing(status)
-    exampleApi.stubHealthPing(status)
+    // exampleApi.stubHealthPing(status)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/health/HealthCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/health/HealthCheckTest.kt
@@ -30,7 +30,7 @@ class HealthCheckTest : IntegrationTestBase() {
       .expectBody()
       .jsonPath("status").isEqualTo("DOWN")
       .jsonPath("components.hmppsAuth.status").isEqualTo("DOWN")
-      .jsonPath("components.exampleApi.status").isEqualTo("DOWN")
+    // .jsonPath("components.exampleApi.status").isEqualTo("DOWN")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/wiremock/ExampleApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/wiremock/ExampleApiMockServer.kt
@@ -1,16 +1,10 @@
 package uk.gov.justice.digital.hmpps.findandreferanintervention.integration.wiremock
 
-import com.github.tomakehurst.wiremock.WireMockServer
-import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
-import com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
-import org.junit.jupiter.api.extension.AfterAllCallback
-import org.junit.jupiter.api.extension.BeforeAllCallback
-import org.junit.jupiter.api.extension.BeforeEachCallback
-import org.junit.jupiter.api.extension.ExtensionContext
 
 // TODO: Remove / replace this mock server as it currently calls the Example API (itself)
-class ExampleApiMockServer : WireMockServer(8091) {
+class ExampleApiMockServer
+/*: WireMockServer(8091) {
   fun stubHealthPing(status: Int) {
     stubFor(
       get("/health/ping").willReturn(
@@ -55,4 +49,4 @@ class ExampleApiExtension : BeforeAllCallback, AfterAllCallback, BeforeEachCallb
   override fun beforeAll(context: ExtensionContext): Unit = exampleApi.start()
   override fun beforeEach(context: ExtensionContext): Unit = exampleApi.resetAll()
   override fun afterAll(context: ExtensionContext): Unit = exampleApi.stop()
-}
+}*/


### PR DESCRIPTION
Remove example mapping for external api call property causing failure