### PR TITLE
rename skeleton project name to relevant name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN addgroup --gid 2000 --system appgroup && \
     adduser --uid 2000 --system appuser --gid 2000
 
 WORKDIR /app
-COPY --from=builder --chown=appuser:appgroup /app/build/libs/hmpps-template-kotlin*.jar /app/app.jar
+COPY --from=builder --chown=appuser:appgroup /app/build/libs/hmpps-find-and-refer-an-intervention-service*.jar /app/app.jar
 COPY --from=builder --chown=appuser:appgroup /app/build/libs/applicationinsights-agent*.jar /app/agent.jar
 COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.json /app
 COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.dev.json /app

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "hmpps-template-kotlin"
+rootProject.name = "hmpps-find-and-refer-an-intervention-service"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/config/OpenApiConfiguration.kt
@@ -1,13 +1,9 @@
 package uk.gov.justice.digital.hmpps.findandreferanintervention.config
 
-import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Contact
 import io.swagger.v3.oas.models.info.Info
-import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
-import io.swagger.v3.oas.models.servers.Server
-import io.swagger.v3.oas.models.tags.Tag
 import org.springframework.boot.info.BuildProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -18,35 +14,10 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
 
   @Bean
   fun customOpenAPI(): OpenAPI = OpenAPI()
-    .servers(
-      listOf(
-        Server().url("https://template-kotlin-dev.hmpps.service.justice.gov.uk").description("Development"),
-        Server().url("https://template-kotlin-preprod.hmpps.service.justice.gov.uk").description("Pre-Production"),
-        Server().url("https://template-kotlin.hmpps.service.justice.gov.uk").description("Production"),
-        Server().url("http://localhost:8080").description("Local"),
-      ),
-    )
-    .tags(
-      listOf(
-        // TODO: Remove the Popular and Examples tag and start adding your own tags to group your resources
-        Tag().name("Popular")
-          .description("The most popular endpoints. Look here first when deciding which endpoint to use."),
-        Tag().name("Examples").description("Endpoints for searching for a prisoner within a prison"),
-      ),
-    )
     .info(
       Info().title("HMPPS Template Kotlin").version(version)
         .contact(Contact().name("HMPPS Digital Studio").email("feedback@digital.justice.gov.uk")),
     )
-    // TODO: Remove the default security schema and start adding your own schemas and roles to describe your
-    // service authorisation requirements
-    .components(
-      Components().addSecuritySchemes(
-        "template-kotlin-ui-role",
-        SecurityScheme().addBearerJwtRequirement("ROLE_TEMPLATE_KOTLIN__UI"),
-      ),
-    )
-    .addSecurityItem(SecurityRequirement().addList("template-kotlin-ui-role", listOf("read")))
 }
 
 private fun SecurityScheme.addBearerJwtRequirement(role: String): SecurityScheme =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/controller/HelloController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/controller/HelloController.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppsfindandreferaninterventionsservice.controller
+package uk.gov.justice.digital.hmpps.findandreferanintervention.controller
 
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/OpenApiDocsTest.kt
@@ -1,11 +1,8 @@
 package uk.gov.justice.digital.hmpps.findandreferanintervention.integration
 
 import io.swagger.v3.parser.OpenAPIV3Parser
-import net.minidev.json.JSONArray
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.CsvSource
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.http.MediaType
 import java.time.LocalDate
@@ -60,46 +57,5 @@ class OpenApiDocsTest : IntegrationTestBase() {
     val result = OpenAPIV3Parser().readLocation("http://localhost:$port/v3/api-docs", null, null)
     assertThat(result.messages).isEmpty()
     assertThat(result.openAPI.paths).isNotEmpty
-  }
-
-  @Test
-  fun `the open api json path security requirements are valid`() {
-    val result = OpenAPIV3Parser().readLocation("http://localhost:$port/v3/api-docs", null, null)
-
-    // The security requirements of each path don't appear to be validated like they are at https://editor.swagger.io/
-    // We therefore need to grab all the valid security requirements and check that each path only contains those items
-    val securityRequirements = result.openAPI.security.flatMap { it.keys }
-    result.openAPI.paths.forEach { pathItem ->
-      assertThat(pathItem.value.get.security.flatMap { it.keys }).isSubsetOf(securityRequirements)
-    }
-  }
-
-  @ParameterizedTest
-  @CsvSource(value = ["template-kotlin-ui-role, ROLE_TEMPLATE_KOTLIN__UI"])
-  fun `the security scheme is setup for bearer tokens`(key: String, role: String) {
-    webTestClient.get()
-      .uri("/v3/api-docs")
-      .accept(MediaType.APPLICATION_JSON)
-      .exchange()
-      .expectStatus().isOk
-      .expectBody()
-      .jsonPath("$.components.securitySchemes.$key.type").isEqualTo("http")
-      .jsonPath("$.components.securitySchemes.$key.scheme").isEqualTo("bearer")
-      .jsonPath("$.components.securitySchemes.$key.description").value<String> {
-        assertThat(it).contains(role)
-      }
-      .jsonPath("$.components.securitySchemes.$key.bearerFormat").isEqualTo("JWT")
-      .jsonPath("$.security[0].$key").isEqualTo(JSONArray().apply { this.add("read") })
-  }
-
-  @Test
-  fun `all endpoints have a security scheme defined`() {
-    webTestClient.get()
-      .uri("/v3/api-docs")
-      .accept(MediaType.APPLICATION_JSON)
-      .exchange()
-      .expectStatus().isOk
-      .expectBody()
-      .jsonPath("$.paths[*][*][?(!@.security)]").doesNotExist()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/controller/HelloControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/controller/HelloControllerTest.kt
@@ -1,7 +1,8 @@
-package uk.gov.justice.digital.hmpps.hmppsfindandreferaninterventionsservice.controller
+package uk.gov.justice.digital.hmpps.findandreferanintervention.integration.controller
 
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.findandreferanintervention.controller.HelloController
 
 internal class HelloControllerTest {
   private val helloController =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/health/InfoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/health/InfoTest.kt
@@ -16,7 +16,7 @@ class InfoTest : IntegrationTestBase() {
       .expectStatus()
       .isOk
       .expectBody()
-      .jsonPath("build.name").isEqualTo("hmpps-template-kotlin")
+      .jsonPath("build.name").isEqualTo("hmpps-find-and-refer-an-intervention-service")
   }
 
   @Test


### PR DESCRIPTION
Rename project from default skeleton name

remove temporary skeleton roles from openAI config. We can add the proper ones/tests back when we have actual endpoints.