### PR TITLE
add test containers for integration tests for running local tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## What does this pull request do?
+
+_Required._
+
+## What is the intent behind these changes?
+
+_Required._

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,6 +74,10 @@ dependencies {
   testImplementation("io.swagger.parser.v3:swagger-parser:2.1.22") {
     exclude(group = "io.swagger.core.v3")
   }
+
+  // Test containers
+  testImplementation("org.springframework.boot:spring-boot-testcontainers")
+  testImplementation("org.testcontainers:postgresql")
 }
 
 kotlin {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/IntegrationTestBase.kt
@@ -5,9 +5,16 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+import org.springframework.boot.test.util.TestPropertyValues
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.web.reactive.server.WebTestClient
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
 import uk.gov.justice.digital.hmpps.findandreferanintervention.integration.wiremock.HmppsAuthApiExtension
 import uk.gov.justice.digital.hmpps.findandreferanintervention.integration.wiremock.HmppsAuthApiExtension.Companion.hmppsAuth
 import uk.gov.justice.hmpps.test.kotlin.auth.JwtAuthorisationHelper
@@ -16,11 +23,41 @@ import uk.gov.justice.hmpps.test.kotlin.auth.JwtAuthorisationHelper
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("integration")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ContextConfiguration(initializers = [IntegrationTestBase.Initializer::class])
 abstract class IntegrationTestBase {
 
-  @Suppress("SpringJavaInjectionPointsAutowiringInspection")
+  companion object {
+    @JvmStatic
+    private val dockerImageName: DockerImageName =
+      DockerImageName.parse("postgres:16").asCompatibleSubstituteFor("postgres")
+
+    @JvmStatic
+    private val postgresContainer: PostgreSQLContainer<*> =
+      PostgreSQLContainer(dockerImageName).apply {
+        withDatabaseName("findandrefer")
+        withUsername("postgres")
+        withPassword("password")
+      }.waitingFor(Wait.forListeningPort())
+  }
+
+  class Initializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+    override fun initialize(applicationContext: ConfigurableApplicationContext) {
+      postgresContainer.start()
+      TestPropertyValues.of(
+        mapOf(
+          "spring.flyway.url" to postgresContainer.jdbcUrl,
+          "spring.flyway.user" to postgresContainer.username,
+          "spring.flyway.password" to postgresContainer.password,
+          "spring.datasource.url" to postgresContainer.jdbcUrl,
+          "spring.datasource.user" to postgresContainer.username,
+          "spring.datasource.password" to postgresContainer.password,
+        ),
+      ).applyTo(applicationContext)
+    }
+  }
+
   @Autowired
-  protected lateinit var webTestClient: WebTestClient
+  lateinit var webTestClient: WebTestClient
 
   @Autowired
   protected lateinit var jwtAuthHelper: JwtAuthorisationHelper


### PR DESCRIPTION
This PR adds support for test containers for running the integration tests locally against a real postgres container without having to separately run them in docker-compose