### PR TITLE
FRI-94: Update RBAC for test endpoint to be Find and Refer Client role

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/controller/DummyController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/controller/DummyController.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.Dummy
 import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.repository.DummyRepository
 
 @RestController
-@PreAuthorize("hasRole('ROLE_INTERVENTIONS_API_READ_ALL')")
+@PreAuthorize("hasRole('ROLE_FIND_AND_REFER_AN_INTERVENTION_API__FAR_UI')")
 class DummyController(
   private val dummyRepository: DummyRepository,
 ) {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 hmpps-auth:
-  url: "http://localhost:8090/auth"
+  url: "http://localhost:9090/auth"
 
 postgres:
   uri: localhost:5433


### PR DESCRIPTION
This PR updates the role to access the test endpoint `/dummy/{id}` to the role of the UI client `ROLE_FIND_AND_REFER_AN_INTERVENTION_API__FAR_UI `