### PR TITLE
FRI-78: Implement InterventionType filter in interventionCatalogueController

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/config/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/config/GlobalExceptionHandler.kt
@@ -9,55 +9,67 @@ import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.servlet.resource.NoResourceFoundException
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.InterventionType
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 @RestControllerAdvice
-class HmppsTemplateKotlinExceptionHandler {
+class GlobalExceptionHandler {
   @ExceptionHandler(ValidationException::class)
-  fun handleValidationException(e: ValidationException): ResponseEntity<ErrorResponse> = ResponseEntity
-    .status(BAD_REQUEST)
+  fun handleValidationException(e: ValidationException): ResponseEntity<ErrorResponse> = ResponseEntity.status(BAD_REQUEST)
     .body(
       ErrorResponse(
         status = BAD_REQUEST,
         userMessage = "Validation failure: ${e.message}",
         developerMessage = e.message,
       ),
-    ).also { log.info("Validation exception: {}", e.message) }
+    )
+    .also { log.info("Validation exception: {}", e.message) }
 
   @ExceptionHandler(NoResourceFoundException::class)
-  fun handleNoResourceFoundException(e: NoResourceFoundException): ResponseEntity<ErrorResponse> = ResponseEntity
-    .status(NOT_FOUND)
+  fun handleNoResourceFoundException(e: NoResourceFoundException): ResponseEntity<ErrorResponse> = ResponseEntity.status(NOT_FOUND)
     .body(
       ErrorResponse(
         status = NOT_FOUND,
         userMessage = "No resource found failure: ${e.message}",
         developerMessage = e.message,
       ),
-    ).also { log.info("No resource found exception: {}", e.message) }
+    )
+    .also { log.info("No resource found exception: {}", e.message) }
 
   @ExceptionHandler(AccessDeniedException::class)
-  fun handleAccessDeniedException(e: AccessDeniedException): ResponseEntity<ErrorResponse> = ResponseEntity
-    .status(FORBIDDEN)
+  fun handleAccessDeniedException(e: AccessDeniedException): ResponseEntity<ErrorResponse> = ResponseEntity.status(FORBIDDEN)
     .body(
       ErrorResponse(
         status = FORBIDDEN,
         userMessage = "Forbidden: ${e.message}",
         developerMessage = e.message,
       ),
-    ).also { log.debug("Forbidden (403) returned: {}", e.message) }
+    )
+    .also { log.debug("Forbidden (403) returned: {}", e.message) }
 
   @ExceptionHandler(Exception::class)
-  fun handleException(e: Exception): ResponseEntity<ErrorResponse> = ResponseEntity
-    .status(INTERNAL_SERVER_ERROR)
+  fun handleException(e: Exception): ResponseEntity<ErrorResponse> = ResponseEntity.status(INTERNAL_SERVER_ERROR)
     .body(
       ErrorResponse(
         status = INTERNAL_SERVER_ERROR,
         userMessage = "Unexpected error: ${e.message}",
         developerMessage = e.message,
       ),
-    ).also { log.error("Unexpected exception", e) }
+    )
+    .also { log.error("Unexpected exception", e) }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+  @ResponseStatus(BAD_REQUEST)
+  fun handleEnumMismatchException(ex: MethodArgumentTypeMismatchException): ResponseEntity<String> {
+    val errorMessage =
+      "Invalid value for InterventionType: ${ex.value}. Valid values are: ${
+        InterventionType.entries}"
+    return ResponseEntity(errorMessage, BAD_REQUEST)
+  }
 
   private companion object {
     private val log = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/controller/InterventionCatalogueController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/controller/InterventionCatalogueController.kt
@@ -7,8 +7,10 @@ import org.springframework.data.web.PageableDefault
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.findandreferanintervention.dto.InterventionCatalogueDto
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.InterventionType
 import uk.gov.justice.digital.hmpps.findandreferanintervention.service.InterventionCatalogueService
 
 @RestController
@@ -20,9 +22,14 @@ class InterventionCatalogueController(
   @GetMapping("/interventions", produces = [MediaType.APPLICATION_JSON_VALUE])
   fun getInterventionsCatalogue(
     @PageableDefault(page = 0, size = 10) pageable: Pageable,
+    @RequestParam(name = "interventionType", required = false)
+    interventionType: InterventionType?,
   ): Page<InterventionCatalogueDto> {
     logToAppInsights()
-    return interventionCatalogueService.getInterventionsCatalogue(pageable)
+    return interventionCatalogueService.getInterventionsCatalogueByCriteria(
+      pageable,
+      interventionType,
+    )
   }
 
   fun logToAppInsights() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/InterventionCatalogueDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/InterventionCatalogueDto.kt
@@ -26,7 +26,9 @@ data class InterventionCatalogueDto(
       val deliveryMethodDtos =
         interventionCatalogue.deliveryMethods.map { DeliveryMethodDto.fromEntity(it) }
       val deliveryMethodSettingList =
-        deliveryMethodDtos.flatMap { methodDto -> methodDto.deliveryMethodSettings.map { settingDto -> settingDto.setting } }
+        deliveryMethodDtos.flatMap { methodDto ->
+          methodDto.deliveryMethodSettings.map { settingDto -> settingDto.setting }
+        }
       return InterventionCatalogueDto(
         id = interventionCatalogue.id,
         title = interventionCatalogue.name,
@@ -37,7 +39,8 @@ data class InterventionCatalogueDto(
         allowsFemales = interventionCatalogue.personalEligibility?.females!!,
         minAge = interventionCatalogue.personalEligibility?.minAge,
         maxAge = interventionCatalogue.personalEligibility?.maxAge,
-        riskCriteria = interventionCatalogue.riskConsideration?.let {
+        riskCriteria =
+        interventionCatalogue.riskConsideration?.let {
           RiskConsiderationDto.fromEntity(it).listOfRisks()
         },
         attendanceType = deliveryMethodDtos.mapNotNull { methodDto -> methodDto.attendanceType },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/repository/InterventionCatalogueFilterRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/repository/InterventionCatalogueFilterRepository.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.repository
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.EntityGraph
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.InterventionCatalogue
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.InterventionType
+
+interface InterventionCatalogueFilterRepository {
+
+  @EntityGraph(
+    attributePaths =
+    [
+      "personalEligibility",
+      "riskConsideration",
+      "criminogenicNeeds",
+      "deliveryLocations",
+      "deliveryMethods",
+      "eligibleOffences",
+      "enablingInterventions",
+      "excludedOffences",
+      "possibleOutcomes",
+      "specialEducationalNeeds",
+      "interventions",
+    ],
+  )
+  fun findAllInterventionCatalogueByCriteria(
+    pageable: Pageable,
+    interventionType: InterventionType?,
+  ): Page<InterventionCatalogue>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/repository/InterventionCatalogueRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/repository/InterventionCatalogueRepository.kt
@@ -1,13 +1,9 @@
 package uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.repository
 
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
-import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.InterventionCatalogue
 import java.util.UUID
 
-interface InterventionCatalogueRepository : JpaRepository<InterventionCatalogue, UUID> {
-  @EntityGraph(attributePaths = ["criminogenicNeeds", "deliveryLocations", "deliveryMethods", "eligibleOffences", "enablingInterventions", "excludedOffences", "exclusion", "interventions", "personalEligibility", "possibleOutcomes", "riskConsideration", "specialEducationalNeeds"])
-  override fun findAll(pageable: Pageable): Page<InterventionCatalogue>
-}
+interface InterventionCatalogueRepository :
+  JpaRepository<InterventionCatalogue, UUID>,
+  InterventionCatalogueFilterRepository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/repository/InterventionCatalogueRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/repository/InterventionCatalogueRepositoryImpl.kt
@@ -1,0 +1,58 @@
+package uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.repository
+
+import jakarta.persistence.EntityManager
+import jakarta.persistence.criteria.CriteriaBuilder
+import jakarta.persistence.criteria.CriteriaQuery
+import jakarta.persistence.criteria.Root
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.InterventionCatalogue
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.InterventionType
+
+class InterventionCatalogueRepositoryImpl(private val entityManager: EntityManager) : InterventionCatalogueFilterRepository {
+
+  private val criteriaBuilder: CriteriaBuilder = entityManager.criteriaBuilder
+
+  override fun findAllInterventionCatalogueByCriteria(
+    pageable: Pageable,
+    interventionType: InterventionType?,
+  ): Page<InterventionCatalogue> {
+    val criteriaQuery: CriteriaQuery<InterventionCatalogue> =
+      criteriaBuilder.createQuery(InterventionCatalogue::class.java)
+    val root: Root<InterventionCatalogue> = criteriaQuery.from(InterventionCatalogue::class.java)
+
+    interventionType?.let { filterByInterventionType(interventionType, criteriaQuery, root) }
+
+    val query = entityManager.createQuery(criteriaQuery)
+    query.setFirstResult(pageable.offset.toInt())
+    query.setMaxResults(pageable.pageSize)
+
+    val resultList = query.resultList
+
+    val totalCount = getTotalCount(interventionType)
+
+    return PageImpl(resultList, pageable, totalCount)
+  }
+
+  private fun <T> filterByInterventionType(
+    interventionType: InterventionType?,
+    criteriaQuery: CriteriaQuery<T>,
+    root: Root<InterventionCatalogue>,
+  ): CriteriaQuery<T> = criteriaQuery.where(
+    criteriaBuilder.equal(root.get<String>("interventionType"), interventionType),
+  )
+
+  private fun getTotalCount(interventionType: InterventionType?): Long {
+    val countCriteriaQuery: CriteriaQuery<Long> = criteriaBuilder.createQuery(Long::class.java)
+    val countRoot: Root<InterventionCatalogue> =
+      countCriteriaQuery.from(InterventionCatalogue::class.java)
+
+    interventionType?.let {
+      filterByInterventionType(interventionType, countCriteriaQuery, countRoot)
+    }
+
+    countCriteriaQuery.select(criteriaBuilder.count(countRoot))
+    return entityManager.createQuery(countCriteriaQuery).singleResult
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/service/InterventionCatalogueService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/service/InterventionCatalogueService.kt
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.findandreferanintervention.dto.InterventionCatalogueDto
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.InterventionType
 import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.repository.InterventionCatalogueRepository
 
 @Service
@@ -11,6 +12,10 @@ class InterventionCatalogueService(
   val interventionCatalogueRepository: InterventionCatalogueRepository,
 ) {
 
-  fun getInterventionsCatalogue(pageable: Pageable): Page<InterventionCatalogueDto> = interventionCatalogueRepository.findAll(pageable)
+  fun getInterventionsCatalogueByCriteria(
+    pageable: Pageable,
+    interventionType: InterventionType?,
+  ): Page<InterventionCatalogueDto> = interventionCatalogueRepository
+    .findAllInterventionCatalogueByCriteria(pageable, interventionType)
     .map { intervention -> InterventionCatalogueDto.fromEntity(intervention) }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/controller/InterventionCatalogueControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/controller/InterventionCatalogueControllerTest.kt
@@ -23,30 +23,33 @@ internal class InterventionCatalogueControllerTest {
     InterventionCatalogueController(interventionCatalogueService, telemetryClient)
 
   @Test
-  fun `getInterventionsCatalogue when present return a paged result of interventions`() {
+  fun `getInterventionsCatalogueByCriteria with no criteria when present return a paged result of interventions`() {
     val pageable = PageRequest.of(0, 10)
-    val catalogue = InterventionCatalogueDto(
-      id = UUID.randomUUID(),
-      title = "Test Title",
-      description = "Test Description",
-      deliveryFormat = listOf("In Person"),
-      interventionType = InterventionType.ACP,
-      setting = listOf(SettingType.COMMUNITY),
-      allowsMales = true,
-      allowsFemales = true,
-      minAge = 18,
-      maxAge = 30,
-      riskCriteria = listOf("RISK_CRITERIA_1", "RISK_CRITERIA_2"),
-      attendanceType = listOf("One-to-one"),
-    )
-    whenever(interventionCatalogueService.getInterventionsCatalogue(pageable)).thenReturn(PageImpl(listOf(catalogue)))
-    val response = interventionCatalogueController.getInterventionsCatalogue(pageable)
+    val catalogue =
+      InterventionCatalogueDto(
+        id = UUID.randomUUID(),
+        title = "Test Title",
+        description = "Test Description",
+        deliveryFormat = listOf("In Person"),
+        interventionType = InterventionType.ACP,
+        setting = listOf(SettingType.COMMUNITY),
+        allowsMales = true,
+        allowsFemales = true,
+        minAge = 18,
+        maxAge = 30,
+        riskCriteria = listOf("RISK_CRITERIA_1", "RISK_CRITERIA_2"),
+        attendanceType = listOf("One-to-one"),
+      )
+    whenever(interventionCatalogueService.getInterventionsCatalogueByCriteria(pageable, null))
+      .thenReturn(PageImpl(listOf(catalogue)))
+    val response = interventionCatalogueController.getInterventionsCatalogue(pageable, null)
 
-    verify(telemetryClient).trackEvent(
-      "InterventionsCatalogue Summary",
-      mapOf("userMessage" to "User has hit interventions catalogue summary page"),
-      null,
-    )
+    verify(telemetryClient)
+      .trackEvent(
+        "InterventionsCatalogue Summary",
+        mapOf("userMessage" to "User has hit interventions catalogue summary page"),
+        null,
+      )
 
     assertThat(response).isNotNull
     assertThat(response.content).isNotEmpty
@@ -70,16 +73,100 @@ internal class InterventionCatalogueControllerTest {
   }
 
   @Test
-  fun `getInterventionsCatalogue when empty return a empty list of interventions`() {
+  fun `getInterventionsCatalogueByCriteria with no criteria when empty return a empty list of interventions`() {
     val pageable = PageRequest.of(0, 10)
-    whenever(interventionCatalogueService.getInterventionsCatalogue(pageable)).thenReturn(PageImpl(listOf()))
-    val response = interventionCatalogueController.getInterventionsCatalogue(pageable)
+    whenever(interventionCatalogueService.getInterventionsCatalogueByCriteria(pageable, null))
+      .thenReturn(PageImpl(listOf()))
+    val response = interventionCatalogueController.getInterventionsCatalogue(pageable, null)
 
-    verify(telemetryClient).trackEvent(
-      "InterventionsCatalogue Summary",
-      mapOf("userMessage" to "User has hit interventions catalogue summary page"),
-      null,
+    verify(telemetryClient)
+      .trackEvent(
+        "InterventionsCatalogue Summary",
+        mapOf("userMessage" to "User has hit interventions catalogue summary page"),
+        null,
+      )
+
+    assertThat(response).isNotNull
+    assertThat(response.content).isEmpty()
+  }
+
+  @Test
+  fun `getInterventionsCatalogueByInterventionType when present return a paged result of interventions`() {
+    val pageable = PageRequest.of(0, 10)
+    val interventionType = InterventionType.ACP
+    val catalogue =
+      InterventionCatalogueDto(
+        id = UUID.randomUUID(),
+        title = "Test Title",
+        description = "Test Description",
+        deliveryFormat = listOf("In Person"),
+        interventionType = InterventionType.ACP,
+        setting = listOf(SettingType.COMMUNITY),
+        allowsMales = true,
+        allowsFemales = true,
+        minAge = 18,
+        maxAge = 30,
+        riskCriteria = listOf("RISK_CRITERIA_1", "RISK_CRITERIA_2"),
+        attendanceType = listOf("One-to-one"),
+      )
+    whenever(
+      interventionCatalogueService.getInterventionsCatalogueByCriteria(
+        pageable,
+        interventionType,
+      ),
     )
+      .thenReturn(PageImpl(listOf(catalogue)))
+    val response =
+      interventionCatalogueController.getInterventionsCatalogue(pageable, interventionType)
+
+    verify(telemetryClient)
+      .trackEvent(
+        "InterventionsCatalogue Summary",
+        mapOf("userMessage" to "User has hit interventions catalogue summary page"),
+        null,
+      )
+
+    assertThat(response).isNotNull
+    assertThat(response.content).isNotEmpty
+    assertThat(
+      response.content.all {
+        it.hasProperty("id")
+        it.hasProperty("title")
+        it.hasProperty("description")
+        it.hasProperty("deliveryFormat")
+        it.hasProperty("interventionTyps")
+        it.hasProperty("setting")
+        it.hasProperty("allowsMales")
+        it.hasProperty("allowsFemales")
+        it.hasProperty("minAge")
+        it.hasProperty("maxAge")
+        it.hasProperty("riskCriteria")
+        it.hasProperty("attendanceType")
+      },
+    )
+    assertThat(response.content[0].title).isEqualTo("Test Title")
+  }
+
+  @Test
+  fun `getInterventionsCatalogueByInterventionType when empty return a paged result of interventions`() {
+    val pageable = PageRequest.of(0, 10)
+    val interventionType = InterventionType.ACP
+    whenever(
+      interventionCatalogueService.getInterventionsCatalogueByCriteria(
+        pageable,
+        interventionType,
+      ),
+    )
+      .thenReturn(PageImpl(listOf()))
+    val response =
+      interventionCatalogueController.getInterventionsCatalogue(pageable, interventionType)
+
+    verify(telemetryClient)
+      .trackEvent(
+        "InterventionsCatalogue Summary",
+        mapOf("userMessage" to "User has hit interventions catalogue summary page"),
+        null,
+      )
 
     assertThat(response).isNotNull
     assertThat(response.content).isEmpty()


### PR DESCRIPTION
This PR implements the `InterventionType` filter in the service.

This endpoint implements a Query parameter of `InterventionType`  `CRS`,`ACP` or `SI`
