### PR TITLE
Implement test factories for Intervention Catalogue

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/CriminogenicNeed.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/CriminogenicNeed.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity
 
+import jakarta.annotation.Nullable
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
@@ -22,4 +23,9 @@ open class CriminogenicNeed(
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "need_id")
   open var need: CriminogenicNeedRef,
+
+  @Nullable
+  @ManyToOne
+  @JoinColumn(name = "intervention_id", referencedColumnName = "id")
+  open var intervention: InterventionCatalogue?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/DeliveryLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/DeliveryLocation.kt
@@ -1,8 +1,11 @@
 package uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity
 
+import jakarta.annotation.Nullable
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
 import java.util.UUID
@@ -26,4 +29,9 @@ open class DeliveryLocation(
   @NotNull
   @Column(name = "pdu_establishments", length = Integer.MAX_VALUE)
   open var pduEstablishments: String,
+
+  @Nullable
+  @ManyToOne
+  @JoinColumn(name = "intervention_id", referencedColumnName = "id")
+  open var intervention: InterventionCatalogue?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/DeliveryMethod.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/DeliveryMethod.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
@@ -34,4 +35,9 @@ open class DeliveryMethod(
   @OneToMany(fetch = FetchType.LAZY)
   @JoinColumn(name = "delivery_method_id", referencedColumnName = "id")
   open var deliveryMethodSettings: MutableSet<DeliveryMethodSetting> = mutableSetOf(),
+
+  @Nullable
+  @ManyToOne
+  @JoinColumn(name = "intervention_id", referencedColumnName = "id")
+  open var intervention: InterventionCatalogue?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/DeliveryMethod.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/DeliveryMethod.kt
@@ -23,10 +23,6 @@ open class DeliveryMethod(
   @Column(name = "attendance_type")
   open var attendanceType: String? = null,
 
-  @NotNull
-  @Column(name = "intervention_id")
-  open var interventionId: UUID,
-
   @Nullable
   @Column(name = "delivery_format")
   open var deliveryFormat: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/EligibleOffence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/EligibleOffence.kt
@@ -31,4 +31,9 @@ open class EligibleOffence(
   @Nullable
   @Column(name = "motivation", length = Integer.MAX_VALUE)
   open var motivation: String? = null,
+
+  @Nullable
+  @ManyToOne
+  @JoinColumn(name = "intervention_id", referencedColumnName = "id")
+  open var intervention: InterventionCatalogue?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/EnablingIntervention.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/EnablingIntervention.kt
@@ -4,6 +4,8 @@ import jakarta.annotation.Nullable
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
 import java.util.UUID
@@ -19,4 +21,9 @@ open class EnablingIntervention(
   @Nullable
   @Column(name = "enabling_intervention_detail", length = Integer.MAX_VALUE)
   open var enablingInterventionDetail: String? = null,
+
+  @Nullable
+  @ManyToOne
+  @JoinColumn(name = "intervention_id", referencedColumnName = "id")
+  open var intervention: InterventionCatalogue?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/ExcludedOffence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/ExcludedOffence.kt
@@ -31,4 +31,9 @@ open class ExcludedOffence(
   @Nullable
   @Column(name = "motivation", length = Integer.MAX_VALUE)
   open var motivation: String? = null,
+
+  @Nullable
+  @ManyToOne
+  @JoinColumn(name = "intervention_id", referencedColumnName = "id")
+  open var intervention: InterventionCatalogue?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/Exclusion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/Exclusion.kt
@@ -47,21 +47,8 @@ open class Exclusion(
   @Column(name = "schedule_frequency_guide", length = Integer.MAX_VALUE)
   open var scheduleFrequencyGuide: String? = null,
 
-  @NotNull
-  @OneToOne(mappedBy = "interventionCatalogue", fetch = FetchType.LAZY, optional = false)
-  @JoinColumn(name = "intervention_id")
-  open var intervention: InterventionCatalogue,
-) {
-  // This is to avoid stack overflow issues with the bi-directional association with referral
-  override fun toString(): String = "Exclusion(id=$id, minRemainingSentenceDurationGuide=$minRemainingSentenceDurationGuide,remainingLicenseCommunityOrderGuide=$remainingLicenseCommunityOrderGuide,alcoholDrugProblemGuide=$alcoholDrugProblemGuide,alcoholDrugProblemGuide=$alcoholDrugProblemGuide,otherPreferredMethodGuide=$otherPreferredMethodGuide,sameTypeRuleGuide=$sameTypeRuleGuide,scheduleFrequencyGuide=$scheduleFrequencyGuide,intervention=$intervention )"
-
-  override fun hashCode(): Int = id.hashCode()
-
-  override fun equals(other: Any?): Boolean {
-    if (other == null || other !is Exclusion) {
-      return false
-    }
-
-    return id == other.id
-  }
-}
+  @Nullable
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "intervention_id", referencedColumnName = "id")
+  open var intervention: InterventionCatalogue?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/Exclusion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/Exclusion.kt
@@ -48,7 +48,20 @@ open class Exclusion(
   open var scheduleFrequencyGuide: String? = null,
 
   @NotNull
-  @OneToOne(fetch = FetchType.LAZY, optional = false)
+  @OneToOne(mappedBy = "interventionCatalogue", fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "intervention_id")
   open var intervention: InterventionCatalogue,
-)
+) {
+  // This is to avoid stack overflow issues with the bi-directional association with referral
+  override fun toString(): String = "Exclusion(id=$id, minRemainingSentenceDurationGuide=$minRemainingSentenceDurationGuide,remainingLicenseCommunityOrderGuide=$remainingLicenseCommunityOrderGuide,alcoholDrugProblemGuide=$alcoholDrugProblemGuide,alcoholDrugProblemGuide=$alcoholDrugProblemGuide,otherPreferredMethodGuide=$otherPreferredMethodGuide,sameTypeRuleGuide=$sameTypeRuleGuide,scheduleFrequencyGuide=$scheduleFrequencyGuide,intervention=$intervention )"
+
+  override fun hashCode(): Int = id.hashCode()
+
+  override fun equals(other: Any?): Boolean {
+    if (other == null || other !is Exclusion) {
+      return false
+    }
+
+    return id == other.id
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/InterventionCatalogue.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/InterventionCatalogue.kt
@@ -102,8 +102,7 @@ open class InterventionCatalogue(
   open var excludedOffences: MutableSet<ExcludedOffence> = mutableSetOf(),
 
   @Nullable
-  @OneToOne
-  @JoinColumn(name = "intervention_id", referencedColumnName = "id")
+  @OneToOne(mappedBy = "intervention")
   open var exclusion: Exclusion? = null,
 
   @ManyToMany
@@ -116,7 +115,6 @@ open class InterventionCatalogue(
 
   @Nullable
   @OneToOne(mappedBy = "intervention")
-  @JoinColumn(name = "intervention_id", referencedColumnName = "id")
   open var personalEligibility: PersonalEligibility? = null,
 
   @OneToMany(fetch = FetchType.LAZY)
@@ -125,7 +123,6 @@ open class InterventionCatalogue(
 
   @Nullable
   @OneToOne(mappedBy = "intervention")
-  @JoinColumn(name = "intervention_id", referencedColumnName = "id")
   open var riskConsideration: RiskConsideration? = null,
 
   @Nullable
@@ -135,20 +132,7 @@ open class InterventionCatalogue(
   @OneToMany(fetch = FetchType.LAZY)
   @JoinColumn(name = "intervention_id", referencedColumnName = "id")
   open var specialEducationalNeeds: MutableSet<SpecialEducationalNeed> = mutableSetOf(),
-) {
-  // This is to avoid stack overflow issues with the bi-directional association with referral
-  override fun toString(): String = "InterventionCatalogue(id=$id,name=$name,shortDescription=$shortDescription,longDescription=$longDescription, topic=$topic,sessionDetail=$sessionDetail,commencementDate=$commencementDate,terminationDate=$terminationDate, created=$created, createdBy=$createdBy, lastModified=$lastModified,lastModifiedBy=$lastModifiedBy, intervetionType=$interventionType,criminogenicNeeds=$criminogenicNeeds),deliveryLocations=$deliveryLocations,deliveryMethods=$deliveryMethods, eligibleOffences=$eligibleOffences, enablingInterventions=$enablingInterventions,excludedOffences=$excludedOffences, exclusion=$exclusion, interventions=$interventions, personalEligibility=$personalEligibility,possibleOutcomes=$possibleOutcomes, riskConsideration=$riskConsideration,reasonsForReferral=$reasonsForReferral, specialEducationNeeds=$specialEducationalNeeds"
-
-  override fun hashCode(): Int = id.hashCode()
-
-  override fun equals(other: Any?): Boolean {
-    if (other == null || other !is InterventionCatalogue) {
-      return false
-    }
-
-    return id == other.id
-  }
-}
+)
 
 enum class InterventionType {
   SI,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/InterventionCatalogue.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/InterventionCatalogue.kt
@@ -77,28 +77,22 @@ open class InterventionCatalogue(
   @JdbcType(PostgreSQLEnumJdbcType::class)
   open var interventionType: InterventionType,
 
-  @OneToMany(fetch = FetchType.LAZY)
-  @JoinColumn(name = "intervention_id", referencedColumnName = "id")
+  @OneToMany(fetch = FetchType.LAZY, mappedBy = "intervention")
   open var criminogenicNeeds: MutableSet<CriminogenicNeed> = mutableSetOf(),
 
-  @OneToMany(fetch = FetchType.LAZY)
-  @JoinColumn(name = "intervention_id", referencedColumnName = "id")
+  @OneToMany(fetch = FetchType.LAZY, mappedBy = "intervention")
   open var deliveryLocations: MutableSet<DeliveryLocation> = mutableSetOf(),
 
-  @OneToMany(fetch = FetchType.LAZY)
-  @JoinColumn(name = "intervention_id", referencedColumnName = "id")
+  @OneToMany(fetch = FetchType.LAZY, mappedBy = "intervention")
   open var deliveryMethods: MutableSet<DeliveryMethod> = mutableSetOf(),
 
-  @OneToMany(fetch = FetchType.LAZY)
-  @JoinColumn(name = "intervention_id", referencedColumnName = "id")
+  @OneToMany(fetch = FetchType.LAZY, mappedBy = "intervention")
   open var eligibleOffences: MutableSet<EligibleOffence> = mutableSetOf(),
 
-  @OneToMany(fetch = FetchType.LAZY)
-  @JoinColumn(name = "intervention_id", referencedColumnName = "id")
+  @OneToMany(fetch = FetchType.LAZY, mappedBy = "intervention")
   open var enablingInterventions: MutableSet<EnablingIntervention> = mutableSetOf(),
 
-  @OneToMany(fetch = FetchType.LAZY)
-  @JoinColumn(name = "intervention_id", referencedColumnName = "id")
+  @OneToMany(fetch = FetchType.LAZY, mappedBy = "intervention")
   open var excludedOffences: MutableSet<ExcludedOffence> = mutableSetOf(),
 
   @Nullable

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/InterventionCatalogue.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/InterventionCatalogue.kt
@@ -102,7 +102,7 @@ open class InterventionCatalogue(
   open var excludedOffences: MutableSet<ExcludedOffence> = mutableSetOf(),
 
   @Nullable
-  @OneToOne(mappedBy = "intervention")
+  @OneToOne
   @JoinColumn(name = "intervention_id", referencedColumnName = "id")
   open var exclusion: Exclusion? = null,
 
@@ -135,7 +135,20 @@ open class InterventionCatalogue(
   @OneToMany(fetch = FetchType.LAZY)
   @JoinColumn(name = "intervention_id", referencedColumnName = "id")
   open var specialEducationalNeeds: MutableSet<SpecialEducationalNeed> = mutableSetOf(),
-)
+) {
+  // This is to avoid stack overflow issues with the bi-directional association with referral
+  override fun toString(): String = "InterventionCatalogue(id=$id,name=$name,shortDescription=$shortDescription,longDescription=$longDescription, topic=$topic,sessionDetail=$sessionDetail,commencementDate=$commencementDate,terminationDate=$terminationDate, created=$created, createdBy=$createdBy, lastModified=$lastModified,lastModifiedBy=$lastModifiedBy, intervetionType=$interventionType,criminogenicNeeds=$criminogenicNeeds),deliveryLocations=$deliveryLocations,deliveryMethods=$deliveryMethods, eligibleOffences=$eligibleOffences, enablingInterventions=$enablingInterventions,excludedOffences=$excludedOffences, exclusion=$exclusion, interventions=$interventions, personalEligibility=$personalEligibility,possibleOutcomes=$possibleOutcomes, riskConsideration=$riskConsideration,reasonsForReferral=$reasonsForReferral, specialEducationNeeds=$specialEducationalNeeds"
+
+  override fun hashCode(): Int = id.hashCode()
+
+  override fun equals(other: Any?): Boolean {
+    if (other == null || other !is InterventionCatalogue) {
+      return false
+    }
+
+    return id == other.id
+  }
+}
 
 enum class InterventionType {
   SI,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/PersonalEligibility.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/PersonalEligibility.kt
@@ -37,6 +37,6 @@ open class PersonalEligibility(
 
   @Nullable
   @OneToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "intervention_id")
-  open var intervention: InterventionCatalogue? = null,
+  @JoinColumn(name = "intervention_id", referencedColumnName = "id")
+  open var intervention: InterventionCatalogue?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/RiskConsideration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/RiskConsideration.kt
@@ -72,10 +72,10 @@ open class RiskConsideration(
   @JdbcType(PostgreSQLEnumJdbcType::class)
   open var roshLevel: RoshLevel?,
 
-  @NotNull
-  @OneToOne(fetch = FetchType.LAZY, optional = false)
-  @JoinColumn(name = "intervention_id")
-  open var intervention: InterventionCatalogue,
+  @Nullable
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "intervention_id", referencedColumnName = "id")
+  open var intervention: InterventionCatalogue?,
 )
 
 enum class RoshLevel {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/controller/InterventionCatalogueControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/controller/InterventionCatalogueControllerTest.kt
@@ -10,37 +10,22 @@ import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import uk.gov.justice.digital.hmpps.findandreferanintervention.controller.InterventionCatalogueController
-import uk.gov.justice.digital.hmpps.findandreferanintervention.dto.InterventionCatalogueDto
 import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.InterventionType
-import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.SettingType
 import uk.gov.justice.digital.hmpps.findandreferanintervention.service.InterventionCatalogueService
-import java.util.UUID
+import uk.gov.justice.digital.hmpps.findandreferanintervention.utils.factories.InterventionCatalogueFactory
+import uk.gov.justice.digital.hmpps.findandreferanintervention.utils.factories.createDto
 
 internal class InterventionCatalogueControllerTest {
   private val telemetryClient = mock<TelemetryClient>()
   private val interventionCatalogueService = mock<InterventionCatalogueService>()
   private val interventionCatalogueController =
     InterventionCatalogueController(interventionCatalogueService, telemetryClient)
+  private val interventionCatalogueFactory: InterventionCatalogueFactory = InterventionCatalogueFactory()
 
   @Test
   fun `getInterventionsCatalogueByCriteria with no criteria when present return a paged result of interventions`() {
     val pageable = PageRequest.of(0, 10)
-    val catalogue =
-      InterventionCatalogueDto(
-        id = UUID.randomUUID(),
-        criminogenicNeeds = listOf("NEED_1", "NEED_2"),
-        title = "Test Title",
-        description = "Test Description",
-        deliveryFormat = listOf("In Person"),
-        interventionType = InterventionType.ACP,
-        setting = listOf(SettingType.COMMUNITY),
-        allowsMales = true,
-        allowsFemales = true,
-        minAge = 18,
-        maxAge = 30,
-        riskCriteria = listOf("RISK_CRITERIA_1", "RISK_CRITERIA_2"),
-        attendanceType = listOf("One-to-one"),
-      )
+    val catalogue = interventionCatalogueFactory.createDto()
     whenever(interventionCatalogueService.getInterventionsCatalogueByCriteria(pageable, null, null, null, null))
       .thenReturn(PageImpl(listOf(catalogue)))
     val response = interventionCatalogueController.getInterventionsCatalogue(pageable, null, null, null, null)
@@ -96,22 +81,7 @@ internal class InterventionCatalogueControllerTest {
   fun `getInterventionsCatalogueByInterventionType when present return a paged result of interventions`() {
     val pageable = PageRequest.of(0, 10)
     val interventionTypes = listOf(InterventionType.ACP)
-    val acpIntervention =
-      InterventionCatalogueDto(
-        id = UUID.randomUUID(),
-        criminogenicNeeds = listOf("NEED_1", "NEED_2"),
-        title = "Test Title",
-        description = "Test Description",
-        deliveryFormat = listOf("In Person"),
-        interventionType = InterventionType.ACP,
-        setting = listOf(SettingType.COMMUNITY),
-        allowsMales = true,
-        allowsFemales = true,
-        minAge = 18,
-        maxAge = 30,
-        riskCriteria = listOf("RISK_CRITERIA_1", "RISK_CRITERIA_2"),
-        attendanceType = listOf("One-to-one"),
-      )
+    val acpIntervention = interventionCatalogueFactory.createDto()
     whenever(
       interventionCatalogueService.getInterventionsCatalogueByCriteria(
         pageable,
@@ -156,38 +126,8 @@ internal class InterventionCatalogueControllerTest {
   fun `getInterventionsCatalogueByInterventionType when searching by multiple types and they are present return a paged result of interventions`() {
     val pageable = PageRequest.of(0, 10)
     val interventionTypes = listOf(InterventionType.ACP, InterventionType.CRS)
-    val acpIntervention =
-      InterventionCatalogueDto(
-        id = UUID.randomUUID(),
-        criminogenicNeeds = listOf("NEED_1", "NEED_2"),
-        title = "Test Title",
-        description = "Test Description",
-        deliveryFormat = listOf("In Person"),
-        interventionType = InterventionType.ACP,
-        setting = listOf(SettingType.COMMUNITY),
-        allowsMales = true,
-        allowsFemales = true,
-        minAge = 18,
-        maxAge = 30,
-        riskCriteria = listOf("RISK_CRITERIA_1", "RISK_CRITERIA_2"),
-        attendanceType = listOf("One-to-one"),
-      )
-    val crsIntervention =
-      InterventionCatalogueDto(
-        id = UUID.randomUUID(),
-        criminogenicNeeds = listOf("NEED_1", "NEED_2"),
-        title = "Test Title",
-        description = "Test Description",
-        deliveryFormat = listOf("In Person"),
-        interventionType = InterventionType.CRS,
-        setting = listOf(SettingType.COMMUNITY),
-        allowsMales = true,
-        allowsFemales = true,
-        minAge = 18,
-        maxAge = 30,
-        riskCriteria = listOf("RISK_CRITERIA_1", "RISK_CRITERIA_2"),
-        attendanceType = listOf("One-to-one"),
-      )
+    val acpIntervention = interventionCatalogueFactory.createDto(interventionType = InterventionType.ACP)
+    val crsIntervention = interventionCatalogueFactory.createDto(interventionType = InterventionType.CRS)
     whenever(
       interventionCatalogueService.getInterventionsCatalogueByCriteria(
         pageable,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/controller/InterventionCatalogueControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/controller/InterventionCatalogueControllerTest.kt
@@ -56,7 +56,7 @@ internal class InterventionCatalogueControllerTest {
       assertThat(item.hasProperty("attendanceType"))
     }
 
-    assertThat(response.content[0].title).isEqualTo("Test Title")
+    assertThat(response.content[0].title).isEqualTo("Finance, Benefit & Debt")
   }
 
   @Test
@@ -119,7 +119,7 @@ internal class InterventionCatalogueControllerTest {
       assertThat(item.hasProperty("riskCriteria"))
       assertThat(item.hasProperty("attendanceType"))
     }
-    assertThat(response.content[0].title).isEqualTo("Test Title")
+    assertThat(response.content[0].title).isEqualTo("Finance, Benefit & Debt")
   }
 
   @Test
@@ -166,7 +166,7 @@ internal class InterventionCatalogueControllerTest {
       assertThat(item.hasProperty("attendanceType"))
     }
     assertThat(response.totalElements).isEqualTo(2)
-    assertThat(response.content[0].title).isEqualTo("Test Title")
+    assertThat(response.content[0].title).isEqualTo("Finance, Benefit & Debt")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/AuthUserFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/AuthUserFactory.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.findandreferanintervention.utils.factories
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.AuthUser
+
+class AuthUserFactory(em: TestEntityManager? = null) : EntityFactory(em)
+
+fun AuthUserFactory.create(
+  id: String = "123456789",
+  authSource: String = "Delius",
+  userName: String = "Robert Mercury",
+  deleted: Boolean = false,
+): AuthUser = save(
+  AuthUser(
+    id,
+    authSource,
+    userName,
+    deleted,
+  ),
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/CriminogenicNeedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/CriminogenicNeedFactory.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.findandreferanintervention.utils.factories
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.CriminogenicNeed
 import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.CriminogenicNeedRef
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.InterventionCatalogue
 import java.util.UUID
 
 class CriminogenicNeedFactory(em: TestEntityManager? = null) : EntityFactory(em)
@@ -10,7 +11,8 @@ class CriminogenicNeedFactory(em: TestEntityManager? = null) : EntityFactory(em)
 fun CriminogenicNeedFactory.create(
   id: UUID = UUID.randomUUID(),
   criminogenicNeedRef: CriminogenicNeedRef = CriminogenicNeedRef(UUID.randomUUID(), "Relationships and Family"),
-): CriminogenicNeed = save(CriminogenicNeed(id, criminogenicNeedRef))
+  intervention: InterventionCatalogue? = null,
+): CriminogenicNeed = save(CriminogenicNeed(id, criminogenicNeedRef, intervention))
 
 fun CriminogenicNeedFactory.createSet(
   id: UUID = UUID.randomUUID(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/CriminogenicNeedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/CriminogenicNeedFactory.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.findandreferanintervention.utils.factories
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.CriminogenicNeed
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.CriminogenicNeedRef
+import java.util.UUID
+
+class CriminogenicNeedFactory(em: TestEntityManager? = null) : EntityFactory(em)
+
+fun CriminogenicNeedFactory.create(
+  id: UUID = UUID.randomUUID(),
+  criminogenicNeedRef: CriminogenicNeedRef = CriminogenicNeedRef(UUID.randomUUID(), "Relationships and Family"),
+): CriminogenicNeed = save(CriminogenicNeed(id, criminogenicNeedRef))
+
+fun CriminogenicNeedFactory.createSet(
+  id: UUID = UUID.randomUUID(),
+  criminogenicNeedRef: CriminogenicNeedRef = CriminogenicNeedRef(UUID.randomUUID(), "Relationships and Family"),
+): MutableSet<CriminogenicNeed> = save(mutableSetOf(create(id, criminogenicNeedRef)))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/EntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/EntityFactory.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.findandreferanintervention.utils.factories
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+
+open class EntityFactory(val em: TestEntityManager?) {
+  inline fun <reified T> save(t: T): T {
+    if (em == null) {
+      return t
+    }
+
+    // if the entity exists, update it. otherwise, save it.
+    if (em.find(T::class.java, em.entityManager.entityManagerFactory.persistenceUnitUtil.getIdentifier(t)) == null) {
+      em.persist(t)
+    } else {
+      em.merge(t)
+    }
+    em.flush()
+    return t
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/ExclusionFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/ExclusionFactory.kt
@@ -29,6 +29,6 @@ fun ExclusionFactory.create(
     otherPreferredMethodGuide,
     ameTypeRuleGuide,
     scheduleFrequencyGuide,
-    intervention ?: interventionCatalogueFactory.create(),
+    intervention,
   ),
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/ExclusionFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/ExclusionFactory.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.findandreferanintervention.utils.factories
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.Exclusion
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.InterventionCatalogue
+import java.util.UUID
+
+class ExclusionFactory(em: TestEntityManager? = null) : EntityFactory(em)
+
+private val interventionCatalogueFactory = InterventionCatalogueFactory()
+
+fun ExclusionFactory.create(
+  id: UUID = UUID.randomUUID(),
+  minRemainingSentenceDurationGuide: String? = null,
+  remainingLicenseCommunityOrderGuide: String? = null,
+  alcoholDrugProblemGuide: String? = null,
+  mentalHealthProblemGuide: String? = null,
+  otherPreferredMethodGuide: String? = null,
+  ameTypeRuleGuide: String? = null,
+  scheduleFrequencyGuide: String? = null,
+  intervention: InterventionCatalogue? = null,
+): Exclusion = save(
+  Exclusion(
+    id,
+    minRemainingSentenceDurationGuide,
+    remainingLicenseCommunityOrderGuide,
+    alcoholDrugProblemGuide,
+    mentalHealthProblemGuide,
+    otherPreferredMethodGuide,
+    ameTypeRuleGuide,
+    scheduleFrequencyGuide,
+    intervention ?: interventionCatalogueFactory.create(),
+  ),
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/InterventionCatalogueFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/InterventionCatalogueFactory.kt
@@ -1,0 +1,152 @@
+package uk.gov.justice.digital.hmpps.findandreferanintervention.utils.factories
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.findandreferanintervention.dto.InterventionCatalogueDto
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.CriminogenicNeed
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.DeliveryLocation
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.DeliveryMethod
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.EligibleOffence
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.EnablingIntervention
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.ExcludedOffence
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.Exclusion
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.Intervention
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.InterventionCatalogue
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.InterventionType
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.PersonalEligibility
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.PossibleOutcome
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.RiskConsideration
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.SpecialEducationalNeed
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+class InterventionCatalogueFactory(em: TestEntityManager? = null) : EntityFactory(em)
+
+private val authUserFactory = AuthUserFactory()
+private val criminogenicNeedFactory = CriminogenicNeedFactory()
+private val exclusionFactory = ExclusionFactory()
+private val riskConsiderationFactory = RiskConsiderationFactory()
+private val personalEligibilityFactory = PersonalEligibilityFactory()
+
+private val testLocalDate: LocalDate = LocalDate.of(2025, 1, 1)
+private val testOffsetDateTime: OffsetDateTime = OffsetDateTime.of(testLocalDate, LocalTime.NOON, ZoneOffset.UTC)
+
+fun InterventionCatalogueFactory.create(
+  id: UUID = UUID.randomUUID(),
+  name: String = "Finance, Benefit & Debt",
+  shortDescription: String = "Service to addresses immediate financial needs",
+  longDescription: String = "In custody FBD services focus on addressing immediate financial needs that arise from being in custody such as freezing debts and stopping benefits.",
+  topic: String = "",
+  sessionDetail: String = "5 x One-to-one sessions and 25 group sessions",
+  commencementDate: LocalDate = testLocalDate,
+  terminationDate: LocalDate = testLocalDate,
+  created: OffsetDateTime = testOffsetDateTime,
+  createdBy: AuthUser = authUserFactory.create(),
+  lastModified: OffsetDateTime = testOffsetDateTime,
+  lastModifiedBy: AuthUser = authUserFactory.create(),
+  interventionType: InterventionType = InterventionType.CRS,
+  criminogenicNeeds: MutableSet<CriminogenicNeed> = criminogenicNeedFactory.createSet(),
+  deliveryLocations: MutableSet<DeliveryLocation> = mutableSetOf(),
+  deliveryMethods: MutableSet<DeliveryMethod> = mutableSetOf(),
+  eligibleOffences: MutableSet<EligibleOffence> = mutableSetOf(),
+  enablingInterventions: MutableSet<EnablingIntervention> = mutableSetOf(),
+  excludedOffences: MutableSet<ExcludedOffence> = mutableSetOf(),
+  exclusion: Exclusion = exclusionFactory.create(),
+  interventions: MutableSet<Intervention> = mutableSetOf(),
+  personalEligibility: PersonalEligibility = personalEligibilityFactory.create(),
+  possibleOutcomes: MutableSet<PossibleOutcome> = mutableSetOf(),
+  riskConsideration: RiskConsideration = riskConsiderationFactory.create(),
+  reasonsForReferral: String = "Lifestyle and associate",
+  specialEducationalNeeds: MutableSet<SpecialEducationalNeed> = mutableSetOf(),
+): InterventionCatalogue = save(
+  InterventionCatalogue(
+    id,
+    name,
+    shortDescription,
+    longDescription,
+    topic,
+    sessionDetail,
+    commencementDate,
+    terminationDate,
+    created,
+    createdBy,
+    lastModified,
+    lastModifiedBy,
+    interventionType,
+    criminogenicNeeds,
+    deliveryLocations,
+    deliveryMethods,
+    eligibleOffences,
+    enablingInterventions,
+    excludedOffences,
+    exclusion,
+    interventions,
+    personalEligibility,
+    possibleOutcomes,
+    riskConsideration,
+    reasonsForReferral,
+    specialEducationalNeeds,
+  ),
+)
+
+fun InterventionCatalogueFactory.createDto(
+  id: UUID = UUID.randomUUID(),
+  name: String = "Finance, Benefit & Debt",
+  shortDescription: String = "Service to addresses immediate financial needs",
+  longDescription: String = "In custody FBD services focus on addressing immediate financial needs that arise from being in custody such as freezing debts and stopping benefits.",
+  topic: String = "",
+  sessionDetail: String = "5 x One-to-one sessions and 25 group sessions",
+  commencementDate: LocalDate = testLocalDate,
+  terminationDate: LocalDate = testLocalDate,
+  created: OffsetDateTime = testOffsetDateTime,
+  createdBy: AuthUser = authUserFactory.create(),
+  lastModified: OffsetDateTime = testOffsetDateTime,
+  lastModifiedBy: AuthUser = authUserFactory.create(),
+  interventionType: InterventionType = InterventionType.CRS,
+  criminogenicNeeds: MutableSet<CriminogenicNeed> = criminogenicNeedFactory.createSet(),
+  deliveryLocations: MutableSet<DeliveryLocation> = mutableSetOf(),
+  deliveryMethods: MutableSet<DeliveryMethod> = mutableSetOf(),
+  eligibleOffences: MutableSet<EligibleOffence> = mutableSetOf(),
+  enablingInterventions: MutableSet<EnablingIntervention> = mutableSetOf(),
+  excludedOffences: MutableSet<ExcludedOffence> = mutableSetOf(),
+  exclusion: Exclusion = exclusionFactory.create(),
+  interventions: MutableSet<Intervention> = mutableSetOf(),
+  personalEligibility: PersonalEligibility = personalEligibilityFactory.create(),
+  possibleOutcomes: MutableSet<PossibleOutcome> = mutableSetOf(),
+  riskConsideration: RiskConsideration = riskConsiderationFactory.create(),
+  reasonsForReferral: String = "Lifestyle and associate",
+  specialEducationalNeeds: MutableSet<SpecialEducationalNeed> = mutableSetOf(),
+): InterventionCatalogueDto {
+  val entity = this.create(
+    id,
+    name,
+    shortDescription,
+    longDescription,
+    topic,
+    sessionDetail,
+    commencementDate,
+    terminationDate,
+    created,
+    createdBy,
+    lastModified,
+    lastModifiedBy,
+    interventionType,
+    criminogenicNeeds,
+    deliveryLocations,
+    deliveryMethods,
+    eligibleOffences,
+    enablingInterventions,
+    excludedOffences,
+    exclusion,
+    interventions,
+    personalEligibility,
+    possibleOutcomes,
+    riskConsideration,
+    reasonsForReferral,
+    specialEducationalNeeds,
+  )
+  return InterventionCatalogueDto.fromEntity(entity)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/InterventionFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/InterventionFactory.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.findandreferanintervention.utils.factories
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.DynamicFrameworkContract
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.Intervention
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+class InterventionFactory(em: TestEntityManager? = null) : EntityFactory(em)
+
+private val testLocalDate: LocalDate = LocalDate.of(2025, 1, 1)
+private val testOffsetDateTime: OffsetDateTime = OffsetDateTime.of(testLocalDate, LocalTime.NOON, ZoneOffset.UTC)
+
+fun InterventionFactory.create(
+  id: UUID = UUID.randomUUID(),
+  dynamicFrameworkContract: DynamicFrameworkContract = TODO(),
+  createdAt: OffsetDateTime = testOffsetDateTime,
+  title: String = "Sheffield Housing Services",
+  description: String = "Inclusive housing for South Yorkshire",
+  incomingReferralDistributionEmail: String = "shs-incoming@provider.example.com",
+): Intervention = save(
+  Intervention(
+    id,
+    dynamicFrameworkContract,
+    createdAt,
+    title,
+    description,
+    incomingReferralDistributionEmail,
+  ),
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/PersonalEligibilityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/PersonalEligibilityFactory.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.findandreferanintervention.utils.factories
 
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.InterventionCatalogue
 import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.PersonalEligibility
 import java.util.UUID
 
@@ -14,6 +15,7 @@ fun PersonalEligibilityFactory.create(
   maxAge: Int? = null,
   males: Boolean = true,
   females: Boolean = false,
+  intervention: InterventionCatalogue? = null,
 ): PersonalEligibility = save(
   PersonalEligibility(
     id,
@@ -21,5 +23,6 @@ fun PersonalEligibilityFactory.create(
     maxAge,
     males,
     females,
+    intervention,
   ),
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/PersonalEligibilityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/PersonalEligibilityFactory.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.findandreferanintervention.utils.factories
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.PersonalEligibility
+import java.util.UUID
+
+class PersonalEligibilityFactory(em: TestEntityManager? = null) : EntityFactory(em)
+
+private val interventionCatalogueFactory = InterventionCatalogueFactory()
+
+fun PersonalEligibilityFactory.create(
+  id: UUID = UUID.randomUUID(),
+  minAge: Int? = null,
+  maxAge: Int? = null,
+  males: Boolean = true,
+  females: Boolean = false,
+): PersonalEligibility = save(
+  PersonalEligibility(
+    id,
+    minAge,
+    maxAge,
+    males,
+    females,
+  ),
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/RiskConsiderationFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/RiskConsiderationFactory.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.findandreferanintervention.utils.factories
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.InterventionCatalogue
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.RiskConsideration
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.RoshLevel
+import java.util.UUID
+
+class RiskConsiderationFactory(em: TestEntityManager? = null) : EntityFactory(em)
+
+private val interventionCatalogueFactory: InterventionCatalogueFactory = InterventionCatalogueFactory()
+
+fun RiskConsiderationFactory.create(
+  id: UUID = UUID.randomUUID(),
+  cnScoreGuide: String? = null,
+  extremismRiskGuide: String? = null,
+  saraPartnerScoreGuide: String? = null,
+  saraOtherScoreGuide: String? = null,
+  ospScoreGuide: String? = null,
+  ospDcIccCombinationGuide: String? = null,
+  ogrsScoreGuide: String? = null,
+  ovpGuide: String? = null,
+  ogpGuide: String? = null,
+  pnaGuide: String? = null,
+  rsrGuide: String? = null,
+  roshLevel: RoshLevel? = null,
+  intervention: InterventionCatalogue = interventionCatalogueFactory.create(),
+): RiskConsideration = save(
+  RiskConsideration(
+    id,
+    cnScoreGuide,
+    extremismRiskGuide,
+    saraPartnerScoreGuide,
+    saraOtherScoreGuide,
+    ospScoreGuide,
+    ospDcIccCombinationGuide,
+    ogrsScoreGuide,
+    ovpGuide,
+    ogpGuide,
+    pnaGuide,
+    rsrGuide,
+    roshLevel,
+    intervention,
+  ),
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/RiskConsiderationFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/RiskConsiderationFactory.kt
@@ -24,7 +24,7 @@ fun RiskConsiderationFactory.create(
   pnaGuide: String? = null,
   rsrGuide: String? = null,
   roshLevel: RoshLevel? = null,
-  intervention: InterventionCatalogue = interventionCatalogueFactory.create(),
+  intervention: InterventionCatalogue? = null,
 ): RiskConsideration = save(
   RiskConsideration(
     id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/RiskConsiderationFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/RiskConsiderationFactory.kt
@@ -8,8 +8,6 @@ import java.util.UUID
 
 class RiskConsiderationFactory(em: TestEntityManager? = null) : EntityFactory(em)
 
-private val interventionCatalogueFactory: InterventionCatalogueFactory = InterventionCatalogueFactory()
-
 fun RiskConsiderationFactory.create(
   id: UUID = UUID.randomUUID(),
   cnScoreGuide: String? = null,


### PR DESCRIPTION
This PR implements the ability to create an InterventionCatalogue entity/dto with default values.

These can be overridden when calling the create() method of the factory e.g.

```kotlin
interventionCatalogueFactory.create(interventionType = "ACP")

```