### PR TITLE
Add title into CRS details response to be displayed at top of UI page

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/CrsInterventionDetailsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/CrsInterventionDetailsDto.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.getPcc
 import java.util.UUID
 
 data class CrsInterventionDetailsDto(
+  val title: String,
   val interventionCatalogueId: UUID,
   val interventionId: UUID,
   val interventionType: InterventionType,
@@ -27,6 +28,7 @@ fun InterventionCatalogue.toCrsDetailsDto(
 ): CrsInterventionDetailsDto {
   val contract = intervention.dynamicFrameworkContract
   return CrsInterventionDetailsDto(
+    title = intervention.title,
     interventionCatalogueId = id,
     interventionId = intervention.id,
     interventionType = interventionType,


### PR DESCRIPTION
This pr adds in the missing `title` field, for CRS details page, that is required to be displayed at the top of the page.

```json
{
  "title": "Kick your Habit",
  "interventionCatalogueId": "ce0bf924-d5eb-498f-9376-8a01a07510f5",
  "interventionId": "3ccb511b-89b2-42f7-803b-304f54d85a24",
  "interventionType": "CRS",
  "npsRegion": "North East",
  "pccRegions": [
    "Cleveland",
    "Durham",
    "Northumbria"
  ],
  "serviceCategories": [
    "Emotional Wellbeing",
    "Family and Significant Others",
    "Lifestyle and Associates",
    "Social Inclusion"
  ],
  "provider": "Home Trust",
  "minAge": 18,
  "maxAge": null,
  "allowsMales": true,
  "allowsFemales": true,
  "description": "Drug and alcohol rehab."
}
```