### PR TITLE
remove postegres.public from flyway migration causing deployment to dev to fail

### DIFF
--- a/src/main/resources/db/migration/V1_38__update_learning_disability_catered_for_to_text.sql
+++ b/src/main/resources/db/migration/V1_38__update_learning_disability_catered_for_to_text.sql
@@ -1,4 +1,4 @@
-ALTER TABLE postgres.public.special_educational_need
+ALTER TABLE special_educational_need
     ALTER COLUMN learning_disability_catered_for DROP NOT NULL,
     ALTER COLUMN learning_disability_catered_for TYPE TEXT USING
         CASE


### PR DESCRIPTION
Remove a `postgres.public`prefix that was added in error and is causing the deployments to dev to fail. Normally we cannot change a migration that has already been merged but since this migration has not ran properly in dev the flyway schema history does not yet include this migration. Therefore I am pretty confident we can just remove the prefix in this migration.