### PR TITLE
Possible Outcomes query return type change

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jobs/scheduled/loadinterventions/UpsertInterventionProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jobs/scheduled/loadinterventions/UpsertInterventionProcessor.kt
@@ -596,22 +596,16 @@ class UpsertInterventionProcessor(
     catalogue: InterventionCatalogue,
   ): MutableSet<PossibleOutcome> {
     val possibleOutcomeList = mutableListOf<PossibleOutcome>()
-    val possibleOutcomesRecord = possibleOutcomeRepository.findByIntervention(catalogue)
+    val possibleOutcomesRecords = possibleOutcomeRepository.findByIntervention(catalogue)
 
     when {
-      possibleOutcomesRecord != null -> {
+      possibleOutcomesRecords?.isNotEmpty() == true -> {
         logger.info(
-          "Retrieved Possible Outcome record from Database for Intervention Catalogue Entry - ${catalogue.name}, id = ${catalogue.id}",
+          "Retrieved ${possibleOutcomesRecords.size} Possible Outcomes record from Database for Intervention Catalogue Entry - " +
+            "${catalogue.name}, id = ${catalogue.id}",
         )
 
-        possibleOutcomesRecord.outcome = possibleOutcomes.toString()
-        possibleOutcomeList.add(possibleOutcomesRecord)
-
-        logger.info(
-          "Possible Outcomes record has now been upserted for Intervention Catalogue Entry - ${catalogue.name}, id = ${catalogue.id}",
-        )
-
-        return possibleOutcomeList.toMutableSet()
+        return possibleOutcomesRecords.toMutableSet()
       }
       else -> {
         for (possibleOutcome in possibleOutcomes) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/repository/PossibleOutcomeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/repository/PossibleOutcomeRepository.kt
@@ -6,5 +6,5 @@ import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.Possib
 import java.util.UUID
 
 interface PossibleOutcomeRepository : JpaRepository<PossibleOutcome, UUID> {
-  fun findByIntervention(intervention: InterventionCatalogue): PossibleOutcome?
+  fun findByIntervention(intervention: InterventionCatalogue): List<PossibleOutcome>?
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/loadinterventions/UpsertInterventionProcessorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/loadinterventions/UpsertInterventionProcessorTest.kt
@@ -752,16 +752,16 @@ internal class UpsertInterventionProcessorTest {
       ObjectMapper().readValue(possibleOutcomeDefinitionJson, object : TypeReference<Array<String>>() {})
 
     whenever(possibleOutcomeRepository.findByIntervention(any())).thenReturn(
-      PossibleOutcome(
-        id = UUID.randomUUID(),
-        outcome = "Prevent users from becoming homeless",
-        intervention = catalogue,
+      listOf(
+        PossibleOutcome(id = UUID.randomUUID(), outcome = "Obtain or maintain suitable accommodation", intervention = catalogue),
+        PossibleOutcome(id = UUID.randomUUID(), outcome = "Overcome barriers to obtaining suitable accommodation", intervention = catalogue),
+        PossibleOutcome(id = UUID.randomUUID(), outcome = "Prevent users from becoming homeless", intervention = catalogue),
       ),
     )
 
     val result = processor.upsertPossibleOutcomes(possibleOutcomeDefinitions, catalogue)
 
-    assertThat(result.count()).isEqualTo(1)
+    assertThat(result.count()).isEqualTo(3)
     verify(possibleOutcomeRepository, times(0)).saveAll(anyList())
   }
 


### PR DESCRIPTION
This PR has been created to correct the return type when retrieving a list of Possible Outcomes. 

Currently upsertInterventionsJob fails during deployment with `IncorrectResultSizeDataAccessException` as query to obtain Possible Outcomes did not return a unique result. This is expected behaviour as there can be more than one Possible Outcomes record associated to an Intervention. 