### PR TITLE
FRI-495 Add enabling intervention, exclusion content 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/EnablingInterventionDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/EnablingInterventionDto.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.findandreferanintervention.dto
+
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.EnablingIntervention
+import java.util.UUID
+
+data class EnablingInterventionDto(
+  val id: UUID,
+  val enablingInterventionDetail: String? = null,
+)
+
+fun EnablingIntervention.toDto(): EnablingInterventionDto = EnablingInterventionDto(
+  id = this.id,
+  enablingInterventionDetail = this.enablingInterventionDetail,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/ExclusionDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/ExclusionDto.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.findandreferanintervention.dto
+
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.Exclusion
+
+data class ExclusionDto(
+  val minRemainingSentenceDuration: String? = null,
+  val remainingLicenseCommunityOrder: String? = null,
+  val alcoholDrugProblem: String? = null,
+  val mentalHealthProblem: String? = null,
+  val otherPreferredMethod: String? = null,
+  val sameTypeRule: String? = null,
+  val scheduleFrequency: String? = null,
+  val notAllowedIfEligibleForAnotherIntervention: String? = null,
+  val literacyLevel: String? = null,
+)
+
+fun Exclusion.toDto(): ExclusionDto = ExclusionDto(
+  minRemainingSentenceDuration = this.minRemainingSentenceDurationGuide,
+  remainingLicenseCommunityOrder = this.remainingLicenseCommunityOrderGuide,
+  alcoholDrugProblem = this.alcoholDrugProblemGuide,
+  mentalHealthProblem = this.mentalHealthProblemGuide,
+  otherPreferredMethod = this.otherPreferredMethodGuide,
+  sameTypeRule = this.sameTypeRuleGuide,
+  scheduleFrequency = this.scheduleFrequencyGuide,
+  notAllowedIfEligibleForAnotherIntervention = this.notAllowedIfEligibleForAnotherInterventionGuide,
+  literacyLevel = this.literacyLevelGuide,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/InterventionDetailsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/InterventionDetailsDto.kt
@@ -15,6 +15,9 @@ data class InterventionDetailsDto(
   val allowsMales: Boolean,
   val allowsFemales: Boolean,
   val criminogenicNeeds: List<String>? = null,
+  val criminogenicNeedScore: String? = null,
+  val eligibleOffence: String? = null,
+  val enablingIntervention: List<String>? = null,
   val interventionType: InterventionType,
   val title: String,
   val minAge: Int? = null,
@@ -30,6 +33,7 @@ data class InterventionDetailsDto(
   val sessionDetails: String? = null,
   val communityLocations: List<CommunityLocation>? = null,
   val custodyLocations: List<CustodyLocation>? = null,
+  val programmeSuitability: ExclusionDto? = null,
 ) {
   data class CommunityLocation(val npsRegion: String, val pdus: MutableSet<PduRefDto>)
 
@@ -39,7 +43,7 @@ data class InterventionDetailsDto(
 fun InterventionCatalogue.toDetailsDto(): InterventionDetailsDto {
   val deliveryMethodDtos =
     this.deliveryMethods.map { DeliveryMethodDto.fromEntity(it) }
-  val deliverylocationDtos = this.deliveryLocations.map { it.toDto() }
+  val deliveryLocationDtos = this.deliveryLocations.map { it.toDto() }
   val courseDtos = this.courses.map { it.toDto() }
 
   return InterventionDetailsDto(
@@ -48,8 +52,13 @@ fun InterventionCatalogue.toDetailsDto(): InterventionDetailsDto {
     this.criminogenicNeeds.map {
       CriminogenicNeedDto.fromEntity(it).need
     }.sorted(),
+    criminogenicNeedScore = riskConsideration?.cnScoreGuide,
     title = this.name,
     description = this.longDescription ?: this.shortDescription,
+    // TODO the way eligible offences are saved to db are not compatible with displaying this as formatted content
+    // eligibleOffence = "",
+    enablingIntervention = this.enablingInterventions.mapNotNull { it.toDto().enablingInterventionDetail }
+      .ifEmpty { null },
     interventionType = this.interventionType,
     allowsMales = this.personalEligibility?.males!!,
     allowsFemales = this.personalEligibility?.females!!,
@@ -64,10 +73,12 @@ fun InterventionCatalogue.toDetailsDto(): InterventionDetailsDto {
     equivalentNonLdcProgramme = this.specialEducationalNeeds?.equivalentNonLdcProgrammeGuide,
     minAge = this.personalEligibility?.minAge,
     maxAge = this.personalEligibility?.maxAge,
-    expectedOutcomes = this.possibleOutcomes.map { it.outcome }.sorted().ifEmpty { null },
+    expectedOutcomes = this.possibleOutcomes.map { it.outcome }.ifEmpty { null },
     sessionDetails = this.sessionDetail,
-    communityLocations = getCommunityLocations(deliverylocationDtos)?.sortedBy { it.npsRegion },
+    communityLocations = getCommunityLocations(deliveryLocationDtos)?.sortedBy { it.npsRegion },
     custodyLocations = getCustodyLocations(courseDtos)?.sortedBy { it.prisonName },
+    // TODO Convicted for offence type is missing from this block as we currently do not save this in a way that allows it to bring back formatted text.
+    programmeSuitability = this.exclusion?.toDto(),
   )
 }
 


### PR DESCRIPTION
This PR adds the required data to the `InterventionsDetailDto` response in order for the data to be displayed in the FE as part of https://dsdmoj.atlassian.net/browse/FRI-495