### PR TITLE
integrating limited access offender check

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/controller/ServiceUserController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/controller/ServiceUserController.kt
@@ -5,7 +5,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import jakarta.validation.constraints.Pattern
 import org.springframework.http.MediaType
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
@@ -35,6 +37,7 @@ class ServiceUserController(
     @PathVariable(name = "identifier")
     @Pattern(regexp = "^([A-Z]\\d{6}|[A-Z]\\d{4}[A-Z]{2})$", message = "Invalid code format. Expected format for CRN: X718255 or PrisonNumber: A1234AA")
     identifier: String,
+    authentication: JwtAuthenticationToken,
   ): ServiceUserDto? {
     telemetryClient.logToAppInsights(
       "retrieve service user details",
@@ -43,6 +46,15 @@ class ServiceUserController(
         "identifier" to identifier,
       ),
     )
+
+    val userName = getUserNameFromAuthentication(authentication)
+    if (service.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(userName, identifier).not()) {
+      throw AccessDeniedException(
+        "You are not authorized to view this person's details. Either contact your administrator or enter a different CRN or Prison Number",
+      )
+    }
     return service.getServiceUserByIdentifier(identifier)
   }
+
+  private fun getUserNameFromAuthentication(authentication: JwtAuthenticationToken): String = authentication.token.getClaimAsString("user_name") ?: "Unknown User"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jobs/scheduled/loadinterventions/UpsertInterventionsJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jobs/scheduled/loadinterventions/UpsertInterventionsJobConfiguration.kt
@@ -2,15 +2,21 @@ package uk.gov.justice.digital.hmpps.findandreferanintervention.jobs.scheduled.l
 
 import mu.KLogging
 import org.springframework.batch.core.Job
+import org.springframework.batch.core.JobParametersBuilder
 import org.springframework.batch.core.Step
+import org.springframework.batch.core.configuration.JobRegistry
 import org.springframework.batch.core.job.builder.JobBuilder
+import org.springframework.batch.core.launch.JobLauncher
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException
 import org.springframework.batch.core.repository.JobRepository
 import org.springframework.batch.core.step.builder.StepBuilder
 import org.springframework.batch.item.ItemReader
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.ApplicationRunner
+import org.springframework.boot.CommandLineRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.annotation.EnableTransactionManagement
 import uk.gov.justice.digital.hmpps.findandreferanintervention.jobs.scheduled.OnStartupJobLauncherFactory
@@ -27,6 +33,25 @@ class UpsertInterventionsJobConfiguration(
 
   @Bean
   fun upsertInterventionsJobLauncher(upsertInterventionsJob: Job): ApplicationRunner = onStartupJobLauncherFactory.makeBatchLauncher(upsertInterventionsJob)
+
+  @Bean
+  @Profile("local")
+  fun jobLauncherCommandlineRunner(jobLauncher: JobLauncher, jobRegistry: JobRegistry): CommandLineRunner = CommandLineRunner { args ->
+    try {
+      val jobNames = listOf("upsertInterventionsJob", "loadDeliveryLocationJob", "loadInterventionCatalogueMapJob", "loadInterventionCatalogueToCourseMapJob")
+      jobNames.forEach { jobName ->
+        val job = jobRegistry.getJob(jobName)
+        logger.info("Running job: $jobName")
+        jobLauncher.run(job, JobParametersBuilder().addLong("time", System.currentTimeMillis()).toJobParameters())
+      }
+    } catch (e: JobExecutionAlreadyRunningException) {
+      logger.error("Job already running, skipping execution", e)
+    } catch (e: Exception) {
+      logger.error("Error running job: ${e.message}", e)
+    } finally {
+      logger.info("Job execution completed")
+    }
+  }
 
   @Bean
   fun upsertInterventionsJob(upsertInterventionsStep: Step, jobRepository: JobRepository): Job {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,6 +81,7 @@ webclient:
 find-and-refer-and-delius:
   locations:
     find-person: "/person/find/{identifier}"
+    limited-access-offender-check: "/user/{username}/access/{identifier}"
 
 management:
   endpoints:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/controller/ServiceUserControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/controller/ServiceUserControllerTest.kt
@@ -2,12 +2,17 @@ package uk.gov.justice.digital.hmpps.findandreferanintervention.integration.cont
 
 import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import uk.gov.justice.digital.hmpps.findandreferanintervention.config.logToAppInsights
 import uk.gov.justice.digital.hmpps.findandreferanintervention.controller.ServiceUserController
 import uk.gov.justice.digital.hmpps.findandreferanintervention.dto.ServiceUserDto
@@ -18,6 +23,14 @@ internal class ServiceUserControllerTest {
   private val service = mock<ServiceUserService>()
   private val telemetryClient = mock<TelemetryClient>()
   private val controller = ServiceUserController(service, telemetryClient)
+
+  private fun jwtAuthToken(): JwtAuthenticationToken {
+    val jwt = Jwt.withTokenValue("token")
+      .header("alg", "none")
+      .claim("user_name", "testuser")
+      .build()
+    return JwtAuthenticationToken(jwt)
+  }
 
   @ParameterizedTest
   @ValueSource(strings = ["X718255", "A1234DE"])
@@ -31,9 +44,10 @@ internal class ServiceUserControllerTest {
       currentPdu = "East Sussex",
       setting = "Community",
     )
+    whenever(service.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(any(), any())).thenReturn(true)
     whenever(service.getServiceUserByIdentifier(any())).thenReturn(testServiceUser)
 
-    val response = controller.serviceUserByCrnOrPrisonerNumber(identifier = identifier)
+    val response = controller.serviceUserByCrnOrPrisonerNumber(identifier = identifier, jwtAuthToken())
 
     verify(telemetryClient).logToAppInsights(
       "retrieve service user details",
@@ -44,5 +58,14 @@ internal class ServiceUserControllerTest {
     assertThat(response?.name).isEqualTo("John")
     assertThat(response?.crn).isEqualTo("X718255")
     assertThat(response?.setting).isEqualTo("Community")
+  }
+
+  @Test
+  fun `throws AccessDeniedException when user does not have access`() {
+    whenever(service.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(any(), any())).thenReturn(false)
+    val exception = assertThrows<AccessDeniedException> {
+      controller.serviceUserByCrnOrPrisonerNumber("X718255", jwtAuthToken())
+    }
+    assertThat(exception.message).isEqualTo("You are not authorized to view this person's details. Either contact your administrator or enter a different CRN or Prison Number")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/controller/ServiceUserControllerValidationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/controller/ServiceUserControllerValidationTest.kt
@@ -1,12 +1,18 @@
 package uk.gov.justice.digital.hmpps.findandreferanintervention.integration.controller
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
-import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
@@ -14,11 +20,11 @@ import org.springframework.test.web.servlet.get
 import uk.gov.justice.digital.hmpps.findandreferanintervention.config.TelemetryClientConfig
 import uk.gov.justice.digital.hmpps.findandreferanintervention.controller.ServiceUserController
 import uk.gov.justice.digital.hmpps.findandreferanintervention.service.ServiceUserService
+import java.util.Collections
 
 @WebMvcTest(ServiceUserController::class)
 @ActiveProfiles("test")
 @Import(TelemetryClientConfig::class)
-@WithMockUser(roles = ["FIND_AND_REFER_AN_INTERVENTION_API__FAR_UI__WR"])
 class ServiceUserControllerValidationTest(@Autowired private val mockMvc: MockMvc) {
 
   @MockitoBean
@@ -27,10 +33,37 @@ class ServiceUserControllerValidationTest(@Autowired private val mockMvc: MockMv
   @ParameterizedTest
   @ValueSource(strings = ["1234567", "A1234A", "X718255X"])
   fun `should return 400 when invalid crn is provided`(identifier: String) {
+    val jwt = Jwt.withTokenValue("token")
+      .header("alg", "none")
+      .claim("user_name", "testuser")
+      .build()
+    val jwtAuth = JwtAuthenticationToken(jwt, Collections.singletonList(SimpleGrantedAuthority("ROLE_FIND_AND_REFER_AN_INTERVENTION_API__FAR_UI__WR"))) // Add appropriate roles
+
+    whenever(serviceUserService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(any(), any())).thenReturn(true)
+
     val response = mockMvc.get("/service-user/{identifier}", identifier) {
+      with(authentication(jwtAuth))
     }.andReturn().response
 
     assertThat(response.status).isEqualTo(400)
     assertThat(response.contentAsString).contains("Invalid code format. Expected format for CRN: X718255 or PrisonNumber: A1234AA")
+  }
+
+  @Test
+  fun `should return 403 when limited access offender check says the user is restricted for this crn or prisoner number`() {
+    val jwt = Jwt.withTokenValue("token")
+      .header("alg", "none")
+      .claim("user_name", "testuser")
+      .build()
+    val jwtAuth = JwtAuthenticationToken(jwt, Collections.singletonList(SimpleGrantedAuthority("ROLE_FIND_AND_REFER_AN_INTERVENTION_API__FAR_UI__WR"))) // Add appropriate roles
+
+    whenever(serviceUserService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(any(), any())).thenReturn(false)
+
+    val response = mockMvc.get("/service-user/{identifier}", "X718255") {
+      with(authentication(jwtAuth))
+    }.andReturn().response
+
+    assertThat(response.status).isEqualTo(403)
+    assertThat(response.contentAsString).contains("You are not authorized to view this person's details. Either contact your administrator or enter a different CRN or Prison Number")
   }
 }

--- a/wiremock_mappings/findAndReferAndMonitorDelius.json
+++ b/wiremock_mappings/findAndReferAndMonitorDelius.json
@@ -1,28 +1,49 @@
 {
-  "request": {
-    "method": "GET",
-    "urlPathPattern": "/person/find/.*"
-  },
-  "response": {
-    "status": 200,
-    "headers": {
-      "Content-Type": "application/json"
+  "mappings": [
+    {
+      "request": {
+        "method": "GET",
+        "urlPathPattern": "/person/find/.*"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "crn": "X718255",
+          "nomsNumber": "A123333",
+          "name": {
+            "forename": "David",
+            "surname": "Clarke"
+          },
+          "dateOfBirth": "1981-04-15",
+          "ethnicity": "British",
+          "gender": "Male",
+          "probationDeliveryUnit": {
+            "code": "LON",
+            "description": "London"
+          },
+          "setting": "Community"
+        }
+      }
     },
-    "jsonBody": {
-      "crn": "X718255",
-      "nomsNumber": "A123333",
-      "name": {
-        "forename": "David",
-        "surname": "Clarke"
+    {
+      "request": {
+        "method": "GET",
+        "urlPathPattern": "/user/.*/access/.*"
       },
-      "dateOfBirth": "1981-04-15",
-      "ethnicity": "British",
-      "gender": "Male",
-      "probationDeliveryUnit": {
-        "code": "LON",
-        "description": "London"
-      },
-      "setting": "Community"
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "crn": "X718255",
+          "userExcluded": false,
+          "userRestricted": false
+        }
+      }
     }
-  }
+  ]
 }


### PR DESCRIPTION
Integrating limited access offender check with `/service-user/{identifier}` service which checks if the user has access to the identifier and if yes progress to retrieving the identifier and if the user does not have access it will throw 403 forbidden error