### PR TITLE
FRI-515: Update riskCriteriaDto

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/InterventionCatalogueDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/InterventionCatalogueDto.kt
@@ -53,8 +53,7 @@ data class InterventionCatalogueDto(
   val allowsMales: Boolean,
 
   val allowsFemales: Boolean,
-
-  val riskCriteria: List<String>?,
+  val riskCriteria: RiskConsiderationDto? = null,
 
   @field:Schema(
     description = "List of Attendance Types held in String (empty if null)",
@@ -124,10 +123,7 @@ fun InterventionCatalogue.toDto(): InterventionCatalogueDto {
     setting = settingList,
     allowsMales = this.personalEligibility?.males!!,
     allowsFemales = this.personalEligibility?.females!!,
-    riskCriteria =
-    this.riskConsideration?.let {
-      RiskConsiderationDto.fromEntity(it).listOfRisks()
-    },
+    riskCriteria = this.riskConsideration?.toDto(),
     attendanceType = this.deliveryMethod?.attendanceType,
     deliveryFormat = this.deliveryMethod?.deliveryFormat,
     timeToComplete = this.timeToComplete,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/InterventionDetailsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/InterventionDetailsDto.kt
@@ -20,7 +20,7 @@ data class InterventionDetailsDto(
   val minAge: Int? = null,
   val maxAge: Int? = null,
   val expectedOutcomes: List<String>? = null,
-  val riskCriteria: List<String>? = null,
+  val riskCriteria: RiskConsiderationDto? = null,
   val suitableForPeopleWithLearningDifficulties: String? = null,
   val equivalentNonLdcProgramme: String? = null,
   val timeToComplete: String? = null,
@@ -51,10 +51,7 @@ fun InterventionCatalogue.toDetailsDto(): InterventionDetailsDto {
     interventionType = this.interventionType,
     allowsMales = this.personalEligibility?.males!!,
     allowsFemales = this.personalEligibility?.females!!,
-    riskCriteria =
-    this.riskConsideration?.let {
-      RiskConsiderationDto.fromEntity(it).listOfRisks()
-    },
+    riskCriteria = this.riskConsideration?.toDto(),
     attendanceType = this.deliveryMethod?.attendanceType,
     deliveryFormat = this.deliveryMethod?.deliveryFormat,
     timeToComplete = this.timeToComplete,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/RiskConsiderationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/RiskConsiderationDto.kt
@@ -1,11 +1,11 @@
 package uk.gov.justice.digital.hmpps.findandreferanintervention.dto
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.RiskConsideration
 import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.RoshLevel
-import java.util.UUID
 
+@JsonInclude(JsonInclude.Include.NON_NULL) // Excludes any properties that have null values when creating dto.
 data class RiskConsiderationDto(
-  val id: UUID,
   val cnScoreGuide: String? = null,
   val extremismRiskGuide: String? = null,
   val saraPartnerScoreGuide: String? = null,
@@ -18,42 +18,19 @@ data class RiskConsiderationDto(
   val pnaGuide: String? = null,
   val rsrGuide: String? = null,
   val roshLevel: RoshLevel? = null,
-) {
+)
 
-  // The Criminogenic Needs Score (cnScoreGuide) has been excluded from this list as it should not be displayed alongside the risk criteria.
-  val listOfRisks: () -> List<String> =
-    {
-      listOfNotNull(
-        extremismRiskGuide,
-        saraPartnerScoreGuide,
-        saraOtherScoreGuide,
-        ospScoreGuide,
-        ospDcIccCombinationGuide,
-        ogrsScoreGuide,
-        ovpGuide,
-        ogpGuide,
-        pnaGuide,
-        rsrGuide,
-        roshLevel?.toString(),
-      ).sorted()
-    }
-
-  companion object {
-
-    fun fromEntity(riskConsideration: RiskConsideration): RiskConsiderationDto = RiskConsiderationDto(
-      id = riskConsideration.id,
-      cnScoreGuide = riskConsideration.cnScoreGuide,
-      extremismRiskGuide = riskConsideration.extremismRiskGuide,
-      saraPartnerScoreGuide = riskConsideration.saraPartnerScoreGuide,
-      saraOtherScoreGuide = riskConsideration.saraOtherScoreGuide,
-      ospScoreGuide = riskConsideration.ospScoreGuide,
-      ospDcIccCombinationGuide = riskConsideration.ospDcIccCombinationGuide,
-      ogrsScoreGuide = riskConsideration.ogrsScoreGuide,
-      ovpGuide = riskConsideration.ovpGuide,
-      ogpGuide = riskConsideration.ogpGuide,
-      pnaGuide = riskConsideration.pnaGuide,
-      rsrGuide = riskConsideration.rsrGuide,
-      roshLevel = riskConsideration.roshLevel,
-    )
-  }
-}
+fun RiskConsideration.toDto(): RiskConsiderationDto = RiskConsiderationDto(
+  cnScoreGuide = this.cnScoreGuide,
+  extremismRiskGuide = this.extremismRiskGuide,
+  saraPartnerScoreGuide = this.saraPartnerScoreGuide,
+  saraOtherScoreGuide = this.saraOtherScoreGuide,
+  ospScoreGuide = this.ospScoreGuide,
+  ospDcIccCombinationGuide = this.ospDcIccCombinationGuide,
+  ogrsScoreGuide = this.ogrsScoreGuide,
+  ovpGuide = this.ovpGuide,
+  ogpGuide = this.ogpGuide,
+  pnaGuide = this.pnaGuide,
+  rsrGuide = this.rsrGuide,
+  roshLevel = this.roshLevel,
+)

--- a/src/test/resources/testData/setup.sql
+++ b/src/test/resources/testData/setup.sql
@@ -25,6 +25,8 @@ FROM delivery_location;
 DELETE
 FROM intervention_catalogue_map;
 DELETE
+FROM intervention_catalogue_to_course_map;
+DELETE
 FROM intervention_catalogue;
 
 INSERT INTO intervention_catalogue (id, name, int_type, short_description, long_description, topic,
@@ -113,17 +115,22 @@ VALUES
 INSERT INTO delivery_method (id, intervention_id, delivery_method_description, delivery_format, attendance_type)
 VALUES
     -- CRS Interventions
-    ('57b42ecb-8774-400f-805b-a7fc7efb0a66', 'c5d53fbd-b7e3-40bd-9096-6720a01a53bf', null, 'Group and One-to-one', 'In Person and Online'),
-    ('dd3acfe4-b62e-4366-955d-296d975cbe34', '47b0048c-cab2-4509-a64a-29a4218712c9', null, 'Group or One-to-one', 'In Person'),
-    ('0855cf84-1249-40ac-8ed5-321b7deb106c', '1e2370d7-be74-4faf-b973-68d258fea015', null, 'Group and One-to-one', 'In Person or Online'),
+    ('57b42ecb-8774-400f-805b-a7fc7efb0a66', 'c5d53fbd-b7e3-40bd-9096-6720a01a53bf', null, 'Group and One-to-one',
+     'In Person and Online'),
+    ('dd3acfe4-b62e-4366-955d-296d975cbe34', '47b0048c-cab2-4509-a64a-29a4218712c9', null, 'Group or One-to-one',
+     'In Person'),
+    ('0855cf84-1249-40ac-8ed5-321b7deb106c', '1e2370d7-be74-4faf-b973-68d258fea015', null, 'Group and One-to-one',
+     'In Person or Online'),
     -- ACP Interventions
-    ('bb8ec055-7448-4594-bf1a-6fbdad1c2ec9', '8380e2d6-ba49-4309-8be7-cc83bf87f372', null, 'Group or One-to-one', 'In Person and Online'),
+    ('bb8ec055-7448-4594-bf1a-6fbdad1c2ec9', '8380e2d6-ba49-4309-8be7-cc83bf87f372', null, 'Group or One-to-one',
+     'In Person and Online'),
     ('95837c47-955a-4364-b73e-0ccefd12681a', '7ce8b4ef-1429-4fc9-a7fe-706aab4dde78', null, 'One-to-one', null),
     ('f1ba6326-6eb7-4422-8c1f-0e312952c48f', 'c5363bae-bd0c-45be-816f-01863cf6396d', null, 'Group', 'In Person'),
     -- SI Interventions
     ('f2433173-2fa7-40a4-8780-04f8c446c61e', '7822b08d-1780-4866-8303-76f1632315ff', null, 'Group', 'In Person'),
     ('4eba09ca-b601-4f3d-b3f0-f4c925600320', '1bca8fb6-2e94-4680-b211-847ffbd9a294', null, 'Group', 'Online'),
-    ('06c3f1fd-b46f-43e1-a581-c3458877b993', '9c697406-e6ab-46c4-9420-1bddaac3193c', null, 'Group and One-to-one', 'In Person or Online'),
+    ('06c3f1fd-b46f-43e1-a581-c3458877b993', '9c697406-e6ab-46c4-9420-1bddaac3193c', null, 'Group and One-to-one',
+     'In Person or Online'),
     -- TOOLKITS Interventions
     ('598154bd-58bd-40dd-a0a5-9c82899b22b1', 'bfbbe2a9-e1d1-453d-88a6-3589f4bda870', null, 'One-to-one', null),
     ('1f512d29-723b-486c-9bee-3bf9bd28e165', 'd97a7462-4035-473e-abe0-afda8c28d1fc', null, 'One-to-one', null),


### PR DESCRIPTION
This PR updates the `RiskCriteriaDto` that is used to display details on the summary and details pages of the UI so that it returns an object containing the values rather than a list. This will allow the FE to own the decision in which the risk criteria is displayed.

![image](https://github.com/user-attachments/assets/b677b0a9-63cb-496d-9fb3-7ca9a9088fa1)

It also refactors the dto to use the `.toDto` extension function pattern that is being used across the project.
