### PR TITLE
fix jakarta sentry version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 
   // monitoring and logging
   implementation("io.micrometer:micrometer-registry-prometheus")
-  implementation("io.sentry:sentry-spring-boot-starter-jakarta:8.15.0")
+  implementation("io.sentry:sentry-spring-boot-starter-jakarta:8.15.1")
   implementation("io.sentry:sentry-logback:8.15.1")
   implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
   implementation("net.logstash.logback:logstash-logback-encoder:8.1")


### PR DESCRIPTION
Seen the following error when attempting to deploy to dev

`ERROR: The Sentry SDK has been configured with mixed versions. Expected maven:io.sentry:sentry-spring-boot-starter-jakarta to match core SDK version 8.15.1 but was 8.15.0`

This PR updates the versions to match