### PR TITLE
APG-966: Fix field names for requirement.created and licence-condition created events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/service/ReferralService.kt
@@ -57,7 +57,7 @@ class ReferralService(
   fun handleLicenceConditionCreatedEvent(hmppsDomainEvent: HmppsDomainEvent, messageId: UUID) {
     val personReference: String = hmppsDomainEvent.personReference.getPersonReferenceTypeAndValue().second!!
     val interventionName: String = hmppsDomainEvent.additionalInformation.getValue("licconditionSubType") as String
-    val sourcedFromReference: String = hmppsDomainEvent.additionalInformation["licconiditionId"] as String
+    val sourcedFromReference: String = hmppsDomainEvent.additionalInformation["licconditionId"] as String
     val existingReferral = referralRepository.findByPersonReferenceAndInterventionNameAndSourcedFromReference(
       personReference,
       interventionName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/service/ReferralService.kt
@@ -24,7 +24,7 @@ class ReferralService(
   fun handleRequirementCreatedEvent(hmppsDomainEvent: HmppsDomainEvent, messageId: UUID) {
     val personReference: String = hmppsDomainEvent.personReference.getPersonReferenceTypeAndValue().second!!
     val interventionName: String = hmppsDomainEvent.additionalInformation.getValue("requirementSubType") as String
-    val sourcedFromReference: String = hmppsDomainEvent.additionalInformation["requirementId"] as String
+    val sourcedFromReference: String = hmppsDomainEvent.additionalInformation["requirementID"] as String
     val existingReferral = referralRepository.findByPersonReferenceAndInterventionNameAndSourcedFromReference(
       personReference,
       interventionName,
@@ -66,7 +66,7 @@ class ReferralService(
     if (existingReferral != null) {
       return logger.info("Duplicate request to create referral from license-condition.created event for Person reference: $personReference, Intervention Name: $interventionName and Reference Id: $sourcedFromReference")
     }
-    logger.info("Saving licence-condition.created event to db with licconiditionId: ${hmppsDomainEvent.additionalInformation["licconiditionId"]}")
+    logger.info("Saving licence-condition.created event to db with licconditionId: ${hmppsDomainEvent.additionalInformation["licconditionId"]}")
     val referral = referralRepository.save(
       Referral(
         id = UUID.randomUUID(),
@@ -76,7 +76,7 @@ class ReferralService(
         personReferenceType = hmppsDomainEvent.personReference.getPersonReferenceTypeAndValue().first,
         personReference = hmppsDomainEvent.personReference.getPersonReferenceTypeAndValue().second!!,
         sourcedFromReferenceType = SourcedFromReferenceType.LICENCE_CONDITION,
-        sourcedFromReference = hmppsDomainEvent.additionalInformation["licconiditionId"] as String,
+        sourcedFromReference = hmppsDomainEvent.additionalInformation["licconditionId"] as String,
       ),
     )
     val message = messageRepository.getReferenceById(messageId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/events/HmppsDomainEventsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/events/HmppsDomainEventsFactory.kt
@@ -40,7 +40,7 @@ fun HmppsDomainEventsFactory.createRequirementCreatedEvent() = this.create(
   additionalInformation = mapOf(
     Pair("requirementSubType", "Breaking Free Online"),
     Pair("requirementMainType", "Court - Accredited Programme"),
-    Pair("requirementId", "2500812305"),
+    Pair("requirementID", "2500812305"),
     Pair("eventNumber", "1"),
     Pair("restrictiveRequirement", "false"),
   ),
@@ -52,7 +52,7 @@ fun HmppsDomainEventsFactory.createLicenceConditionCreatedEvent() = this.create(
   additionalInformation = mapOf(
     Pair("licconditionSubType", "Horizon"),
     Pair("licconditionMainType", "License - Accredited Programme"),
-    Pair("licconiditionId", "2500782763"),
+    Pair("licconditionId", "2500782763"),
     Pair("eventNumber", "1"),
   ),
   occurredAt = ZonedDateTime.now(),

--- a/src/test/resources/testData/events/probation-case/licenseConditionCreatedEvent.json
+++ b/src/test/resources/testData/events/probation-case/licenseConditionCreatedEvent.json
@@ -3,7 +3,7 @@
   "MessageId": "f39059e7-a62d-4157-929a-fb049015c993",
   "Token": null,
   "TopicArn": "arn:aws:sns:eu-west-2:000000000000:hmpps-domain",
-  "Message": "{\"eventType\":\"probation-case.licence-condition.created\",\"version\":\"1\",\"description\":\"A Licence Condition has been created in Delius\",\"occurredAt\":\"2025-06-26T09:18:21.89+01:00\",\"additionalInformation\":{\"licconditionMainType\":\"License - AccreditedProgramme\",\"licconiditionId\":\"2500782763\",\"eventNumber\":\"1\",\"licconditionSubType\":\"Horizon\"},\"personReference\":{\"identifiers\":[{\"type\":\"CRN\",\"value\":\"X929377\"}]}}",
+  "Message": "{\"eventType\":\"probation-case.licence-condition.created\",\"version\":\"1\",\"description\":\"A Licence Condition has been created in Delius\",\"occurredAt\":\"2025-06-26T09:18:21.89+01:00\",\"additionalInformation\":{\"licconditionMainType\":\"License - AccreditedProgramme\",\"licconditionId\":\"2500782763\",\"eventNumber\":\"1\",\"licconditionSubType\":\"Horizon\"},\"personReference\":{\"identifiers\":[{\"type\":\"CRN\",\"value\":\"X929377\"}]}}",
   "SubscribeURL": null,
   "Timestamp": "2021-10-21T06:27:57.028Z",
   "SignatureVersion": "1",

--- a/src/test/resources/testData/events/probation-case/requirementCreatedEvent.json
+++ b/src/test/resources/testData/events/probation-case/requirementCreatedEvent.json
@@ -3,7 +3,7 @@
   "MessageId": "f39059e7-a62d-4157-929a-fb049015c993",
   "Token": null,
   "TopicArn": "arn:aws:sns:eu-west-2:000000000000:hmpps-domain",
-  "Message": "{\"eventType\":\"probation-case.requirement.created\",\"version\":\"1\",\"description\":\"A requirement has been created in Delius\",\"occurredAt\":\"2025-06-26T09:18:21.89+01:00\",\"additionalInformation\":{\"requirementSubType\":\"Breaking Free Online\",\"requirementMainType\":\"Court - Accredited Programme\",\"requirementId\":\"2500812305\",\"eventNumber\":\"1\",\"restrictiveRequirement\":\"false\"},\"personReference\":{\"identifiers\":[{\"type\":\"CRN\",\"value\":\"X929377\"}]}}",
+  "Message": "{\"eventType\":\"probation-case.requirement.created\",\"version\":\"1\",\"description\":\"A requirement has been created in Delius\",\"occurredAt\":\"2025-06-26T09:18:21.89+01:00\",\"additionalInformation\":{\"requirementSubType\":\"Breaking Free Online\",\"requirementMainType\":\"Court - Accredited Programme\",\"requirementID\":\"2500812305\",\"eventNumber\":\"1\",\"restrictiveRequirement\":\"false\"},\"personReference\":{\"identifiers\":[{\"type\":\"CRN\",\"value\":\"X929377\"}]}}",
   "SubscribeURL": null,
   "Timestamp": "2021-10-21T06:27:57.028Z",
   "SignatureVersion": "1",


### PR DESCRIPTION
This PR fixes the handling of events in the dev environment due to differences in the expected property names.

The following error has been fixed;
`Caused by: java.lang.NullPointerException: null cannot be cast to non-null type kotlin.String`