### PR TITLE
APG-1100: Add getReferralById endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/controller/ReferralController.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.findandreferanintervention.controller
+
+import com.microsoft.applicationinsights.TelemetryClient
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import uk.gov.justice.digital.hmpps.findandreferanintervention.config.logToAppInsights
+import uk.gov.justice.digital.hmpps.findandreferanintervention.dto.ReferralDetailsDto
+import uk.gov.justice.digital.hmpps.findandreferanintervention.service.ReferralService
+import java.util.UUID
+
+@RestController
+@PreAuthorize("hasRole('ROLE_ACCREDITED_PROGRAMMES_MANAGE_AND_DELIVER_API__ACPMAD_UI_WR')")
+class ReferralController(
+  private val referralService: ReferralService,
+  private val telemetryClient: TelemetryClient,
+) {
+
+  @GetMapping(
+    "/referral/{referralId}",
+    produces = [MediaType.APPLICATION_JSON_VALUE],
+    name = "Get a Referral by Referral Id",
+  )
+  @ApiResponse(responseCode = "200", description = "OK")
+  fun getReferralDetails(@PathVariable referralId: UUID): ReferralDetailsDto? {
+    telemetryClient.logToAppInsights(
+      "Received request for referral details",
+      mapOf("referralId" to referralId.toString()),
+    )
+    return referralService.getReferralDetailsById(referralId) ?: throw ResponseStatusException(
+      HttpStatus.NOT_FOUND,
+      "Referral Not Found with ID: $referralId",
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/ReferralDetailsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/ReferralDetailsDto.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.findandreferanintervention.dto
+
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.InterventionType
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.PersonReferenceType
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.SettingType
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.SourcedFromReferenceType
+import java.util.UUID
+
+data class ReferralDetailsDto(
+  val interventionType: InterventionType,
+  val interventionName: String,
+  val personReference: String,
+  val personReferenceType: PersonReferenceType,
+  val referralId: UUID,
+  val setting: SettingType,
+  val sourcedFromReference: String,
+  val sourcedFromReferenceType: SourcedFromReferenceType,
+)
+
+fun Referral.toDto(): ReferralDetailsDto = ReferralDetailsDto(
+  interventionType = this.interventionType,
+  interventionName = this.interventionName,
+  personReference = this.personReference,
+  personReferenceType = this.personReferenceType,
+  referralId = this.id,
+  setting = this.settingType,
+  sourcedFromReference = this.sourcedFromReference,
+  sourcedFromReferenceType = this.sourcedFromReferenceType,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/entity/Referral.kt
@@ -20,10 +20,6 @@ open class Referral(
   open var id: UUID,
 
   @NotNull
-  @Column(name = "person_reference", length = Integer.MAX_VALUE)
-  open var personReference: String,
-
-  @NotNull
   @Column(name = "setting")
   @Enumerated(EnumType.STRING)
   @JdbcType(PostgreSQLEnumJdbcType::class)
@@ -37,7 +33,11 @@ open class Referral(
 
   @NotNull
   @Column(name = "intervention_name", length = Integer.MAX_VALUE)
-  open var interventionName: String? = null,
+  open var interventionName: String,
+
+  @NotNull
+  @Column(name = "person_reference", length = Integer.MAX_VALUE)
+  open var personReference: String,
 
   @NotNull
   @Column(name = "person_reference_type")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/jpa/repository/ReferralRepository.kt
@@ -6,6 +6,8 @@ import java.util.UUID
 
 interface ReferralRepository : JpaRepository<Referral, UUID> {
 
+  fun findReferralById(referralId: UUID): Referral?
+
   fun findByPersonReferenceAndInterventionNameAndSourcedFromReference(
     personReference: String,
     interventionName: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/service/ReferralService.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.findandreferanintervention.service
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.findandreferanintervention.dto.ReferralDetailsDto
+import uk.gov.justice.digital.hmpps.findandreferanintervention.dto.toDto
 import uk.gov.justice.digital.hmpps.findandreferanintervention.event.HmppsDomainEvent
 import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.InterventionType
 import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.Referral
@@ -20,6 +22,8 @@ class ReferralService(
 ) {
 
   private val logger = LoggerFactory.getLogger(this::class.java)
+
+  fun getReferralDetailsById(referralId: UUID): ReferralDetailsDto? = referralRepository.findReferralById(referralId)?.toDto()
 
   fun handleRequirementCreatedEvent(hmppsDomainEvent: HmppsDomainEvent, messageId: UUID) {
     val personReference: String = hmppsDomainEvent.personReference.getPersonReferenceTypeAndValue().second!!

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/controller/ReferralControllerTest.kt
@@ -1,0 +1,74 @@
+package uk.gov.justice.digital.hmpps.findandreferanintervention.controller
+
+import com.microsoft.applicationinsights.TelemetryClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.context.annotation.Import
+import org.springframework.web.server.ResponseStatusException
+import uk.gov.justice.digital.hmpps.findandreferanintervention.config.TelemetryClientConfig
+import uk.gov.justice.digital.hmpps.findandreferanintervention.config.logToAppInsights
+import uk.gov.justice.digital.hmpps.findandreferanintervention.dto.toDto
+import uk.gov.justice.digital.hmpps.findandreferanintervention.service.ReferralService
+import uk.gov.justice.digital.hmpps.findandreferanintervention.utils.factories.ReferralFactory
+import uk.gov.justice.digital.hmpps.findandreferanintervention.utils.factories.create
+import java.util.UUID
+
+@Import(TelemetryClientConfig::class)
+class ReferralControllerTest {
+
+  private val telemetryClient = mock<TelemetryClient>()
+  private val referralService = mock<ReferralService>()
+  private val referralController: ReferralController = ReferralController(referralService, telemetryClient)
+  private val referralFactory: ReferralFactory = ReferralFactory()
+
+  @BeforeEach
+  fun beforeEach() {
+    doNothing().`when`(telemetryClient).logToAppInsights(
+      "InterventionsCatalogue Summary",
+      mapOf("userMessage" to "User has hit interventions catalogue summary page"),
+    )
+  }
+
+  @AfterEach
+  fun afterEach() {
+    reset(telemetryClient)
+  }
+
+  @Test
+  fun `get referral with existing id returns a referralDetailsDto`() {
+    val referral = referralFactory.create()
+    whenever(referralService.getReferralDetailsById(any())).thenReturn(referral.toDto())
+
+    val response = referralController.getReferralDetails(referral.id)
+    verify(telemetryClient, times(1)).logToAppInsights(
+      "Received request for referral details",
+      mapOf("referralId" to referral.id.toString()),
+    )
+    assertThat(response).isNotNull
+    assertThat(response!!).isEqualTo(referral.toDto())
+  }
+
+  @Test
+  fun `get referral with non existent id returns Not Found exception`() {
+    val randomUuid = UUID.randomUUID()
+    whenever(referralService.getReferralDetailsById(any())).thenReturn(null)
+    val exception = assertThrows<ResponseStatusException> {
+      referralController.getReferralDetails(randomUuid)
+    }
+    assertThat(exception.message).isEqualTo("404 NOT_FOUND \"Referral Not Found with ID: $randomUuid\"")
+    verify(telemetryClient, times(1)).logToAppInsights(
+      "Received request for referral details",
+      mapOf("referralId" to randomUuid.toString()),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/GetReferralDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/GetReferralDetailsTest.kt
@@ -1,0 +1,130 @@
+package uk.gov.justice.digital.hmpps.findandreferanintervention.integration
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.core.io.ResourceLoader
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.jdbc.datasource.init.ScriptUtils
+import uk.gov.justice.digital.hmpps.findandreferanintervention.dto.ReferralDetailsDto
+import uk.gov.justice.digital.hmpps.findandreferanintervention.dto.toDto
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.findandreferanintervention.utils.makeErrorResponse
+import uk.gov.justice.digital.hmpps.findandreferanintervention.utils.makeRequestAndExpectJsonResponse
+import uk.gov.justice.digital.hmpps.findandreferanintervention.utils.makeRequestAndExpectStatus
+import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
+import java.util.UUID
+import javax.sql.DataSource
+
+class GetReferralDetailsTest : IntegrationTestBase() {
+  @Autowired
+  private lateinit var referralRepository: ReferralRepository
+
+  @Autowired
+  private lateinit var dataSource: DataSource
+
+  @Autowired
+  private lateinit var resourceLoader: ResourceLoader
+
+  @BeforeEach
+  fun beforeEach() {
+    dataSource.connection.use {
+      val r = resourceLoader.getResource("classpath:testData/setup.sql")
+      ScriptUtils.executeSqlScript(it, r)
+    }
+  }
+
+  @AfterEach
+  fun afterEach() {
+    dataSource.connection.use {
+      val r = resourceLoader.getResource("classpath:testData/teardown.sql")
+      ScriptUtils.executeSqlScript(it, r)
+    }
+  }
+
+  @Test
+  fun `getReferral details for Licence condition created referral returns 200 and referralDetailsDto`() {
+    val referralId = UUID.fromString("3e183d36-85c2-4a43-8ca5-ff6422b064cb")
+    val referralDetailsDto = referralRepository.findReferralById(referralId)!!.toDto()
+
+    makeRequestAndExpectJsonResponse(
+      testClient = webTestClient,
+      httpMethod = HttpMethod.GET,
+      uri = { it.path("/referral/$referralId").build() },
+      requestCustomizer = { headers(setAuthorisation(roles = listOf("ROLE_ACCREDITED_PROGRAMMES_MANAGE_AND_DELIVER_API__ACPMAD_UI_WR"))) },
+      expectedStatus = HttpStatus.OK,
+      responseType = ReferralDetailsDto::class.java,
+      expectedResponse = referralDetailsDto,
+    )
+  }
+
+  @Test
+  fun `getReferral details for Requirement created referral returns 200 and referralDetailsDto`() {
+    val referralId = UUID.fromString("a410c4bd-027a-436a-a3f4-4fa22039e314")
+    val referralDetailsDto = referralRepository.findReferralById(referralId)!!.toDto()
+
+    makeRequestAndExpectJsonResponse(
+      testClient = webTestClient,
+      httpMethod = HttpMethod.GET,
+      uri = { it.path("/referral/$referralId").build() },
+      requestCustomizer = { headers(setAuthorisation(roles = listOf("ROLE_ACCREDITED_PROGRAMMES_MANAGE_AND_DELIVER_API__ACPMAD_UI_WR"))) },
+      expectedStatus = HttpStatus.OK,
+      responseType = ReferralDetailsDto::class.java,
+      expectedResponse = referralDetailsDto,
+    )
+  }
+
+  @Test
+  fun `getReferralDetails for non-existent ID return 404 NOT FOUND`() {
+    val referralId = UUID.randomUUID()
+    val expectedErrorResponse = makeErrorResponse(
+      status = HttpStatus.NOT_FOUND,
+      userMessage = "Referral Not Found with ID: $referralId",
+      developerMessage = "404 NOT_FOUND \"Referral Not Found with ID: $referralId\"",
+    )
+
+    makeRequestAndExpectJsonResponse(
+      testClient = webTestClient,
+      httpMethod = HttpMethod.GET,
+      uri = { it.path("/referral/$referralId").build() },
+      requestCustomizer = { headers(setAuthorisation(roles = listOf("ROLE_ACCREDITED_PROGRAMMES_MANAGE_AND_DELIVER_API__ACPMAD_UI_WR"))) },
+      expectedStatus = HttpStatus.NOT_FOUND,
+      responseType = ErrorResponse::class.java,
+      expectedResponse = expectedErrorResponse,
+    )
+  }
+
+  @Test
+  fun `getReferralDetails for non UUID return 400 BAD REQUEST`() {
+    val referralId = " INVALID_UUID"
+    val expectedErrorResponse = makeErrorResponse(
+      status = HttpStatus.BAD_REQUEST,
+      userMessage = "Invalid value for parameter referralId",
+      developerMessage = "Method parameter 'referralId': Failed to convert value of type 'java.lang.String' to required type 'java.util.UUID'; Invalid UUID string: INVALID_UUID",
+    )
+    makeRequestAndExpectJsonResponse(
+      testClient = webTestClient,
+      httpMethod = HttpMethod.GET,
+      uri = { it.path("/referral/$referralId").build() },
+      requestCustomizer = { headers(setAuthorisation(roles = listOf("ROLE_ACCREDITED_PROGRAMMES_MANAGE_AND_DELIVER_API__ACPMAD_UI_WR"))) },
+      expectedStatus = HttpStatus.BAD_REQUEST,
+      responseType = ErrorResponse::class.java,
+      expectedResponse = expectedErrorResponse,
+    )
+  }
+
+  @Test
+  fun `getReferralDetails for non Authorised User return 401 Unauthorized`() {
+    val referralId = UUID.randomUUID()
+
+    makeRequestAndExpectStatus(
+      testClient = webTestClient,
+      httpMethod = HttpMethod.GET,
+      uri = { it.path("/referral/$referralId").build() },
+      requestCustomizer = { },
+      expectedStatus = HttpStatus.UNAUTHORIZED,
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/GetReferralDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/GetReferralDetailsTest.kt
@@ -33,6 +33,8 @@ class GetReferralDetailsTest : IntegrationTestBase() {
     dataSource.connection.use {
       val r = resourceLoader.getResource("classpath:testData/setup.sql")
       ScriptUtils.executeSqlScript(it, r)
+      val referrals = resourceLoader.getResource("classpath:testData/referrals.sql")
+      ScriptUtils.executeSqlScript(it, referrals)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/ReferralFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/ReferralFactory.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.findandreferanintervention.utils.factories
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.InterventionType
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.PersonReferenceType
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.SettingType
+import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.SourcedFromReferenceType
+import java.util.UUID
+
+class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em)
+
+fun ReferralFactory.create(
+  id: UUID = UUID.randomUUID(),
+  settingType: SettingType = SettingType.COMMUNITY,
+  interventionType: InterventionType = InterventionType.ACP,
+  interventionName: String = "Horizon",
+  personReference: String = "EXAMPLE_CRN",
+  personReferenceType: PersonReferenceType = PersonReferenceType.CRN,
+  sourcedFromReferenceType: SourcedFromReferenceType = SourcedFromReferenceType.REQUIREMENT,
+  sourcedFromReference: String = "EXAMPLE_REFERENCE",
+): Referral = save(
+  Referral(
+    id = id,
+    settingType = settingType,
+    interventionType = interventionType,
+    interventionName = interventionName,
+    personReference = personReference,
+    personReferenceType = personReferenceType,
+    sourcedFromReferenceType = sourcedFromReferenceType,
+    sourcedFromReference = sourcedFromReference,
+  ),
+)

--- a/src/test/resources/testData/referrals.sql
+++ b/src/test/resources/testData/referrals.sql
@@ -1,0 +1,7 @@
+INSERT INTO referral (id, person_reference, setting, intervention_type, intervention_name, person_reference_type,
+                      sourced_from_reference_type, sourced_from_reference)
+VALUES ('3e183d36-85c2-4a43-8ca5-ff6422b064cb', 'X929377', 'COMMUNITY', 'ACP', 'Horizon', 'CRN', 'LICENCE_CONDITION',
+        '2500782763'),
+       ('a410c4bd-027a-436a-a3f4-4fa22039e314', 'X931759', 'COMMUNITY', 'ACP', 'Requirement Length Extended', 'CRN',
+        'REQUIREMENT',
+        '2500816306');

--- a/src/test/resources/testData/setup.sql
+++ b/src/test/resources/testData/setup.sql
@@ -304,15 +304,3 @@ VALUES -- SI Interventions
 
 INSERT INTO intervention_catalogue_map(intervention_catalogue_id, intervention_id)
 VALUES ('c5d53fbd-b7e3-40bd-9096-6720a01a53bf', '65301f01-2e52-474a-a8ec-df94c7e6fced');
-
-INSERT INTO referral (id, person_reference, setting, intervention_type, intervention_name, person_reference_type,
-                      sourced_from_reference_type, sourced_from_reference)
-VALUES ('3e183d36-85c2-4a43-8ca5-ff6422b064cb', 'X929377', 'COMMUNITY', 'ACP', 'Horizon', 'CRN', 'LICENCE_CONDITION',
-        '2500782763'),
-       ('a410c4bd-027a-436a-a3f4-4fa22039e314', 'X931759', 'COMMUNITY', 'ACP', 'Requirement Length Extended', 'CRN',
-        'REQUIREMENT',
-        '2500816306');
-
-
-
-

--- a/src/test/resources/testData/setup.sql
+++ b/src/test/resources/testData/setup.sql
@@ -305,8 +305,13 @@ VALUES -- SI Interventions
 INSERT INTO intervention_catalogue_map(intervention_catalogue_id, intervention_id)
 VALUES ('c5d53fbd-b7e3-40bd-9096-6720a01a53bf', '65301f01-2e52-474a-a8ec-df94c7e6fced');
 
-
-
+INSERT INTO referral (id, person_reference, setting, intervention_type, intervention_name, person_reference_type,
+                      sourced_from_reference_type, sourced_from_reference)
+VALUES ('3e183d36-85c2-4a43-8ca5-ff6422b064cb', 'X929377', 'COMMUNITY', 'ACP', 'Horizon', 'CRN', 'LICENCE_CONDITION',
+        '2500782763'),
+       ('a410c4bd-027a-436a-a3f4-4fa22039e314', 'X931759', 'COMMUNITY', 'ACP', 'Requirement Length Extended', 'CRN',
+        'REQUIREMENT',
+        '2500816306');
 
 
 


### PR DESCRIPTION
This pr implements the `getReferralById` endpoint. This returns a ReferralDetailsDto object which looks like:

```json
{
    "interventionType": "ACP",
    "interventionName": "Horizon",
    "personReference": "X929377",
    "personReferenceType": "CRN",
    "referralId": "cf4e36f0-4922-42ba-8e78-a64411f9c5e7",
    "setting": "COMMUNITY",
    "sourcedFromReference": "2500782763",
    "sourcedFromReferenceType": "LICENCE_CONDITION"
}
```