### PR TITLE
configuring prometheus endpoint for find and refer intervention

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,9 @@ dependencies {
   implementation("org.hibernate:hibernate-core:7.0.4.Final")
   implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.10.1")
 
+  // monitoring
+  implementation("io.micrometer:micrometer-registry-prometheus")
+
   runtimeOnly("org.postgresql:postgresql:42.7.7")
   runtimeOnly("org.flywaydb:flyway-database-postgresql")
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -120,7 +120,13 @@ management:
     web:
       base-path: /
       exposure:
-        include: 'info, health'
+        include: 'info, health, prometheus'
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+    tags:
+      application: find-and-refer-an-intervention
   endpoint:
     health:
       cache:


### PR DESCRIPTION
configuring prometheus endpoint for find and refer intervention. This work enables the `/prometheus` endpoint which should enable us the jvm related stats to prometheus