### PR TITLE
APG-1120: Only create ACP referrals when the event main type is correct

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/service/ReferralService.kt
@@ -33,6 +33,10 @@ class ReferralService(
   fun getReferralDetailsById(referralId: UUID): ReferralDetailsDto? = referralRepository.findReferralById(referralId)?.toDto()
 
   fun handleRequirementCreatedEvent(hmppsDomainEvent: HmppsDomainEvent, messageId: UUID) {
+    val requirementMainType = hmppsDomainEvent.additionalInformation.getValue("requirementMainType")
+    if (hmppsDomainEvent.additionalInformation.getValue("requirementMainType") == null || requirementMainType != "Court - Accredited Programme") {
+      return logger.info("requirementMainType is not for creation of an Accredited Programme. requirementMainType: $requirementMainType and messageId: $messageId)")
+    }
     val personReference: String = hmppsDomainEvent.personReference.getPersonReferenceTypeAndValue().second!!
     val interventionName: String = hmppsDomainEvent.additionalInformation.getValue("requirementSubType") as String
     val sourcedFromReference: String = hmppsDomainEvent.additionalInformation["requirementID"] as String
@@ -68,6 +72,10 @@ class ReferralService(
   }
 
   fun handleLicenceConditionCreatedEvent(hmppsDomainEvent: HmppsDomainEvent, messageId: UUID) {
+    val licconditionMainType = hmppsDomainEvent.additionalInformation.getValue("licconditionMainType")
+    if (hmppsDomainEvent.additionalInformation.getValue("licconditionMainType") == null || licconditionMainType != "License - Accredited Programme") {
+      return logger.info("licconditionMainType is not for creation of an Accredited Programme. licconditionMainType: $licconditionMainType and messageId: $messageId)")
+    }
     val personReference: String = hmppsDomainEvent.personReference.getPersonReferenceTypeAndValue().second!!
     val interventionName: String = hmppsDomainEvent.additionalInformation.getValue("licconditionSubType") as String
     val sourcedFromReference: String = hmppsDomainEvent.additionalInformation["licconditionId"] as String

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/events/HmppsDomainEventsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/factories/events/HmppsDomainEventsFactory.kt
@@ -35,25 +35,36 @@ fun HmppsDomainEventsFactory.create(
   ),
 )
 
-fun HmppsDomainEventsFactory.createRequirementCreatedEvent() = this.create(
+fun HmppsDomainEventsFactory.createRequirementCreatedEvent(
+  requirementSubType: String? = "Breaking Free Online",
+  requirementMainType: String? = "Court - Accredited Programme",
+  requirementID: String? = "2500812305",
+  eventNumber: String? = "1",
+  restrictiveRequirement: String? = "false",
+) = this.create(
   eventType = "probation-case.requirement.created",
   additionalInformation = mapOf(
-    Pair("requirementSubType", "Breaking Free Online"),
-    Pair("requirementMainType", "Court - Accredited Programme"),
-    Pair("requirementID", "2500812305"),
-    Pair("eventNumber", "1"),
-    Pair("restrictiveRequirement", "false"),
+    Pair("requirementSubType", requirementSubType),
+    Pair("requirementMainType", requirementMainType),
+    Pair("requirementID", requirementID),
+    Pair("eventNumber", eventNumber),
+    Pair("restrictiveRequirement", restrictiveRequirement),
   ),
   occurredAt = ZonedDateTime.now(),
 )
 
-fun HmppsDomainEventsFactory.createLicenceConditionCreatedEvent() = this.create(
+fun HmppsDomainEventsFactory.createLicenceConditionCreatedEvent(
+  licconditionSubType: String? = "Horizon",
+  licconditionMainType: String? = "License - Accredited Programme",
+  licconditionId: String? = "2500782763",
+  eventNumber: String? = "1",
+) = this.create(
   eventType = "probation-case.licence-condition.created",
   additionalInformation = mapOf(
-    Pair("licconditionSubType", "Horizon"),
-    Pair("licconditionMainType", "License - Accredited Programme"),
-    Pair("licconditionId", "2500782763"),
-    Pair("eventNumber", "1"),
+    Pair("licconditionSubType", licconditionSubType),
+    Pair("licconditionMainType", licconditionMainType),
+    Pair("licconditionId", licconditionId),
+    Pair("eventNumber", eventNumber),
   ),
   occurredAt = ZonedDateTime.now(),
 )


### PR DESCRIPTION
We wrongly made the assumption that all `probation-case.requirement.created' and 'probation-case.licence-condition.created` events would lead to the creation of a referral in ACP community. 

This pr ensures that we only create referrals when the respective `mainType` of the event is either:
* Court - Accredited Programme
* License - Accredited Programme