### PR TITLE
APG-1170: Add documentation around the ReferralDetailsDto

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/controller/ReferralController.kt
@@ -1,7 +1,13 @@
 package uk.gov.justice.digital.hmpps.findandreferanintervention.controller
 
 import com.microsoft.applicationinsights.TelemetryClient
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
@@ -16,6 +22,7 @@ import java.util.UUID
 
 @PreAuthorize("hasRole('ROLE_ACCREDITED_PROGRAMMES_MANAGE_AND_DELIVER_API__ACPMAD_UI_WR')")
 @RestController
+@Tag(name = "Referrals", description = "API for managing intervention referrals")
 class ReferralController(
   private val referralService: ReferralService,
   private val telemetryClient: TelemetryClient,
@@ -26,8 +33,44 @@ class ReferralController(
     produces = [MediaType.APPLICATION_JSON_VALUE],
     name = "Get a Referral by Referral Id",
   )
-  @ApiResponse(responseCode = "200", description = "OK")
-  fun getReferralDetails(@PathVariable referralId: UUID): ReferralDetailsDto? {
+  @Operation(
+    summary = "Get referral details by ID",
+    description = "Retrieves detailed information about a specific referral including probation case information.  Used primarily by the Manage & Deliver service, in response to an Event.",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Referral details found and returned successfully",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ReferralDetailsDto::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Referral not found with the provided ID",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized - authentication required",
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden - insufficient permissions",
+      ),
+    ],
+  )
+  fun getReferralDetails(
+    @Parameter(
+      description = "The unique identifier (UUID) of the referral to retrieve",
+      required = true,
+      example = "c0edf32e-c7be-5625-a971-9201b244e9e2",
+    )
+    @PathVariable referralId: UUID,
+  ): ReferralDetailsDto? {
     telemetryClient.logToAppInsights(
       "Received request for referral details",
       mapOf("referralId" to referralId.toString()),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/ReferralDetailsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/dto/ReferralDetailsDto.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.findandreferanintervention.dto
 
+import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.InterventionType
 import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.PersonReferenceType
 import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.Referral
@@ -7,15 +8,33 @@ import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.Settin
 import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.entity.SourcedFromReferenceType
 import java.util.UUID
 
+@Schema(description = "Full details of the Referral")
 data class ReferralDetailsDto(
+  @field:Schema(description = "The type of intervention", example = "ACP")
   val interventionType: InterventionType,
+
+  @field:Schema(description = "The name of the intervention")
   val interventionName: String,
+
+  @field:Schema(description = "The person reference (CRN or NOMS number, see personReferencType)")
   val personReference: String,
+
+  @field:Schema(description = "The type of person reference, detailed in personReference")
   val personReferenceType: PersonReferenceType,
+
+  @field:Schema(description = "The unique identifier for this referral")
   val referralId: UUID,
+
+  @field:Schema(description = "The setting where the intervention will take place", example = "COMMUNITY")
   val setting: SettingType,
+
+  @field:Schema(description = "The upstream event reference type", example = "requirement")
   val sourcedFromReference: String,
+
+  @field:Schema(description = "A unique identifier to the sourceFromReference", example = "abc123")
   val sourcedFromReferenceType: SourcedFromReferenceType,
+
+  @field:Schema(description = "The event number from the source system")
   val eventNumber: Int,
 )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/GetReferralDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/integration/GetReferralDetailsTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.findandreferanintervention.dto.ReferralDetai
 import uk.gov.justice.digital.hmpps.findandreferanintervention.dto.toDto
 import uk.gov.justice.digital.hmpps.findandreferanintervention.jpa.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.findandreferanintervention.utils.makeErrorResponse
+import uk.gov.justice.digital.hmpps.findandreferanintervention.utils.makeRequestAndExpectJsonPathResponse
 import uk.gov.justice.digital.hmpps.findandreferanintervention.utils.makeRequestAndExpectJsonResponse
 import uk.gov.justice.digital.hmpps.findandreferanintervention.utils.makeRequestAndExpectStatus
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
@@ -60,6 +61,18 @@ class GetReferralDetailsTest : IntegrationTestBase() {
       responseType = ReferralDetailsDto::class.java,
       expectedResponse = referralDetailsDto,
     )
+
+    @Test
+    fun `getReferral details for a Licence Condition stringifies the value appropriately`() {
+      makeRequestAndExpectJsonPathResponse(
+        testClient = webTestClient,
+        httpMethod = HttpMethod.GET,
+        uri = { it.path("/referral/$referralId").build() },
+        requestCustomizer = { headers(setAuthorisation(roles = listOf("ROLE_ACCREDITED_PROGRAMMES_MANAGE_AND_DELIVER_API__ACPMAD_UI_WR"))) },
+        fieldName = "sourcedFromReferenceType",
+        expectedValue = "LICENCE_CONDITION",
+      )
+    }
   }
 
   @Test
@@ -75,6 +88,20 @@ class GetReferralDetailsTest : IntegrationTestBase() {
       expectedStatus = HttpStatus.OK,
       responseType = ReferralDetailsDto::class.java,
       expectedResponse = referralDetailsDto,
+    )
+  }
+
+  @Test
+  fun `getReferral details for a Requirement stringifies the value appropriately`() {
+    val referralId = UUID.fromString("a410c4bd-027a-436a-a3f4-4fa22039e314")
+
+    makeRequestAndExpectJsonPathResponse(
+      testClient = webTestClient,
+      httpMethod = HttpMethod.GET,
+      uri = { it.path("/referral/$referralId").build() },
+      requestCustomizer = { headers(setAuthorisation(roles = listOf("ROLE_ACCREDITED_PROGRAMMES_MANAGE_AND_DELIVER_API__ACPMAD_UI_WR"))) },
+      fieldName = "sourcedFromReferenceType",
+      expectedValue = "REQUIREMENT",
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/HttpRequestHelpers.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/findandreferanintervention/utils/HttpRequestHelpers.kt
@@ -38,6 +38,22 @@ fun <T> makeRequestAndExpectJsonResponse(
   .expectBody(responseType)
   .isEqualTo(expectedResponse)
 
+fun makeRequestAndExpectJsonPathResponse(
+  testClient: WebTestClient,
+  httpMethod: HttpMethod,
+  uri: (UriBuilder) -> URI,
+  requestCustomizer: WebTestClient.RequestHeadersSpec<*>.() -> Unit,
+  fieldName: String,
+  expectedValue: String,
+): WebTestClient.BodyContentSpec = testClient.method(httpMethod)
+  .uri(uri)
+  .apply(requestCustomizer)
+  .exchange()
+  .expectStatus()
+  .isOk
+  .expectBody()
+  .jsonPath(fieldName).isEqualTo(expectedValue)
+
 fun makeRequestAndExpectStatus(
   testClient: WebTestClient,
   httpMethod: HttpMethod,


### PR DESCRIPTION
**WHAT**

This is a sibling commit to a change made in the manage-and-deliver
service, which introduces some better documentation and annotations to
code around the Referrals endpoints.

**WHY**

We are about to start using the sourced_from data (license or
requirement) in the manage-and-deliver service.  This PR is a bit of a
tidy-up alongside using that, to make sure it's clear what is being sent
over, and what the data represents.
